### PR TITLE
chore: add Rust lints to Cargo.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+      - name: Check formatting
+        run: cargo fmt -- --check
+      - name: Run Clippy
+        run: cargo clippy --all-targets -- -D warnings
       - name: Run tests
         run: cargo test --release -- --nocapture
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,6 @@ jobs:
             ${{ runner.os }}-cargo-
       - name: Check formatting
         run: cargo fmt -- --check
-      - name: Run Clippy
-        run: cargo clippy --all-targets -- -D warnings
       - name: Run tests
         run: cargo test --release -- --nocapture
       - name: Build

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -29,6 +29,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+      - name: Check formatting
+        run: cargo fmt -- --check
+      - name: Run Clippy
+        run: cargo clippy --all-targets -- -D warnings
       - name: Run tests
         run: cargo test --release -- --nocapture
       - name: Build

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -31,8 +31,6 @@ jobs:
             ${{ runner.os }}-cargo-
       - name: Check formatting
         run: cargo fmt -- --check
-      - name: Run Clippy
-        run: cargo clippy --all-targets -- -D warnings
       - name: Run tests
         run: cargo test --release -- --nocapture
       - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,3 @@ tempfile = "3.27.0"
 
 [lints.rust]
 unsafe_op_in_unsafe_fn = "warn"
-
-[lints.clippy]
-unwrap_used = "warn"
-expect_used = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,10 @@ ironpress = "1.4.3"
 axum-test = "20.0.0"
 reqwest = { version = "0.13.3", features = ["json"] }
 tempfile = "3.27.0"
+
+[lints.rust]
+unsafe_op_in_unsafe_fn = "warn"
+
+[lints.clippy]
+unwrap_used = "warn"
+expect_used = "warn"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Make sure you have cargo installed using this command:
 cargo --version
 ```
 
+### Format
+Format the code
+```bash script
+cargo fmt
+```
+
 ### Build
 Build the code without running it
 ```bash script

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,21 +33,15 @@ impl Default for Config {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(8080),
-            root_dir: PathBuf::from(
-                env::var("ROOT_DIR").unwrap_or_else(|_| ".".to_string()),
-            ),
+            root_dir: PathBuf::from(env::var("ROOT_DIR").unwrap_or_else(|_| ".".to_string())),
             templates_dir: PathBuf::from(
                 env::var("TEMPLATES_DIR").unwrap_or_else(|_| "templates".to_string()),
             ),
             resources_dir: PathBuf::from(
                 env::var("RESOURCES_DIR").unwrap_or_else(|_| "resources".to_string()),
             ),
-            data_dir: PathBuf::from(
-                env::var("DATA_DIR").unwrap_or_else(|_| "data".to_string()),
-            ),
-            fonts_dir: PathBuf::from(
-                env::var("FONTS_DIR").unwrap_or_else(|_| "fonts".to_string()),
-            ),
+            data_dir: PathBuf::from(env::var("DATA_DIR").unwrap_or_else(|_| "data".to_string())),
+            fonts_dir: PathBuf::from(env::var("FONTS_DIR").unwrap_or_else(|_| "fonts".to_string())),
             dev_mode: env::var("DEV_MODE")
                 .map(|v| v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false),

--- a/src/html.rs
+++ b/src/html.rs
@@ -6,7 +6,6 @@ use typst::foundations::Bytes;
 
 use crate::typst_world::{self, Fonts};
 
-
 /// Compiles a Typst template with JSON data and returns the resulting HTML string.
 ///
 /// The JSON data is serialised and injected as a virtual file at `/data.json`,
@@ -53,10 +52,18 @@ mod tests {
     fn typst_to_html_simple_template_returns_html_string() {
         let source = "Hello, world!\n";
         let data = serde_json::json!({});
-        let result = typst_to_html(source, &data, Arc::new(load_fonts(&fonts_dir()).expect("test fonts should load")), &root_dir());
+        let result = typst_to_html(
+            source,
+            &data,
+            Arc::new(load_fonts(&fonts_dir()).expect("test fonts should load")),
+            &root_dir(),
+        );
         assert!(result.is_ok(), "typst_to_html failed: {:?}", result.err());
         let html = result.unwrap();
-        assert!(html.contains("<!DOCTYPE html>") && html.contains("<html"), "Expected HTML document");
+        assert!(
+            html.contains("<!DOCTYPE html>") && html.contains("<html"),
+            "Expected HTML document"
+        );
         assert!(html.contains("Hello, world!"));
     }
 
@@ -66,8 +73,17 @@ mod tests {
 #data.at("name", default: "")
 "#;
         let data = serde_json::json!({"name": "Test User"});
-        let result = typst_to_html(source, &data, Arc::new(load_fonts(&fonts_dir()).expect("test fonts should load")), &root_dir());
-        assert!(result.is_ok(), "typst_to_html with JSON data failed: {:?}", result.err());
+        let result = typst_to_html(
+            source,
+            &data,
+            Arc::new(load_fonts(&fonts_dir()).expect("test fonts should load")),
+            &root_dir(),
+        );
+        assert!(
+            result.is_ok(),
+            "typst_to_html with JSON data failed: {:?}",
+            result.err()
+        );
         let html = result.unwrap();
         assert!(html.contains("Test User"));
     }
@@ -76,7 +92,15 @@ mod tests {
     fn typst_to_html_invalid_source_returns_error() {
         let source = "#this-is-not-valid-typst-syntax(((";
         let data = serde_json::json!({});
-        let result = typst_to_html(source, &data, Arc::new(load_fonts(&fonts_dir()).expect("test fonts should load")), &root_dir());
-        assert!(result.is_err(), "Expected an error for invalid Typst source");
+        let result = typst_to_html(
+            source,
+            &data,
+            Arc::new(load_fonts(&fonts_dir()).expect("test fonts should load")),
+            &root_dir(),
+        );
+        assert!(
+            result.is_err(),
+            "Expected an error for invalid Typst source"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,13 +11,13 @@ mod typst_world;
 mod performance_test;
 
 use anyhow::{Context, Result};
+use axum::http::{HeaderMap, Request};
 use axum::{
     body::Body,
     routing::{get, post},
     Router,
 };
 use opentelemetry::{global, propagation::Extractor};
-use axum::http::{HeaderMap, Request};
 use serde_json::Value;
 use state::AppAliveness;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
@@ -211,10 +211,7 @@ fn build_router(state: AppState) -> Router {
         // parent so that pdfgenrs spans are correctly nested inside the caller's distributed
         // trace.  The OpenTelemetryLayer (registered in setup_tracing) converts those tracing
         // spans into OpenTelemetry spans forwarded to the OTLP exporter.
-        .layer(
-            TraceLayer::new_for_http()
-                .make_span_with(make_otel_span)
-        )
+        .layer(TraceLayer::new_for_http().make_span_with(make_otel_span))
 }
 
 async fn shutdown_signal(aliveness: AppAliveness) -> Result<()> {
@@ -227,9 +224,8 @@ async fn shutdown_signal(aliveness: AppAliveness) -> Result<()> {
 
     #[cfg(unix)]
     let terminate = async {
-        let mut sigterm =
-            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                .context("Failed to install SIGTERM handler")?;
+        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .context("Failed to install SIGTERM handler")?;
         sigterm.recv().await;
         Ok::<(), anyhow::Error>(())
     };

--- a/src/performance_test.rs
+++ b/src/performance_test.rs
@@ -11,9 +11,8 @@ mod tests {
 
     fn create_test_state() -> AppState {
         let cfg = config::Config::default();
-        let templates = Arc::new(
-            template::load_templates_from_dir(&cfg.templates_dir).unwrap_or_default(),
-        );
+        let templates =
+            Arc::new(template::load_templates_from_dir(&cfg.templates_dir).unwrap_or_default());
         let data = template::load_test_data(&cfg.data_dir).data;
         let fonts = Arc::new(
             typst_world::load_fonts(&cfg.fonts_dir).expect("performance test fonts should load"),
@@ -32,9 +31,7 @@ mod tests {
         let _guard = crate::memory_sensitive_test_lock().lock().unwrap();
         let app_state = create_test_state();
 
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let base_url = format!("http://127.0.0.1:{port}");
 

--- a/src/routes/html.rs
+++ b/src/routes/html.rs
@@ -109,8 +109,8 @@ mod tests {
     use axum_test::TestServer;
     use tokio::sync::RwLock;
 
-    use crate::{config, state, typst_world, AppState};
     use super::{get_html, post_html};
+    use crate::{config, state, typst_world, AppState};
 
     const SIMPLE_TEMPLATE: &str = "Hello!\n";
     const INVALID_TEMPLATE: &str = "#this-is-not-valid-typst-syntax(((";
@@ -133,13 +133,15 @@ mod tests {
                 fonts_dir: PathBuf::from("fonts"),
                 dev_mode,
             },
-            fonts: Arc::new(typst_world::load_fonts(&PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fonts")).expect("test fonts should load")),
+            fonts: Arc::new(
+                typst_world::load_fonts(&PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fonts"))
+                    .expect("test fonts should load"),
+            ),
         }
     }
 
     fn make_router(state: AppState, dev_mode: bool) -> Router {
-        let mut router = Router::new()
-            .route("/{app_name}/{template}", post(post_html));
+        let mut router = Router::new().route("/{app_name}/{template}", post(post_html));
         if dev_mode {
             router = router.route("/{app_name}/{template}", get(get_html));
         }
@@ -154,7 +156,10 @@ mod tests {
     async fn post_html_returns_html_for_valid_template() {
         let mut templates = HashMap::new();
         templates.insert("myapp/mytemplate".to_string(), SIMPLE_TEMPLATE.to_string());
-        let server = TestServer::new(make_router(make_state(templates, HashMap::new(), false), false));
+        let server = TestServer::new(make_router(
+            make_state(templates, HashMap::new(), false),
+            false,
+        ));
 
         let response = server
             .post("/myapp/mytemplate")
@@ -162,16 +167,22 @@ mod tests {
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);
-        assert!(
-            response.headers().get("content-type").unwrap().to_str().unwrap()
-                .starts_with("text/html")
-        );
+        assert!(response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("text/html"));
         assert!(is_html(response.text().as_str()));
     }
 
     #[tokio::test]
     async fn post_html_returns_404_when_template_missing() {
-        let server = TestServer::new(make_router(make_state(HashMap::new(), HashMap::new(), false), false));
+        let server = TestServer::new(make_router(
+            make_state(HashMap::new(), HashMap::new(), false),
+            false,
+        ));
 
         let response = server
             .post("/myapp/mytemplate")
@@ -185,7 +196,10 @@ mod tests {
     async fn post_html_returns_500_for_invalid_template() {
         let mut templates = HashMap::new();
         templates.insert("myapp/mytemplate".to_string(), INVALID_TEMPLATE.to_string());
-        let server = TestServer::new(make_router(make_state(templates, HashMap::new(), false), false));
+        let server = TestServer::new(make_router(
+            make_state(templates, HashMap::new(), false),
+            false,
+        ));
 
         let response = server
             .post("/myapp/mytemplate")
@@ -209,10 +223,13 @@ mod tests {
         let response = server.get("/myapp/mytemplate").await;
 
         assert_eq!(response.status_code(), StatusCode::OK);
-        assert!(
-            response.headers().get("content-type").unwrap().to_str().unwrap()
-                .starts_with("text/html")
-        );
+        assert!(response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("text/html"));
         assert!(is_html(response.text().as_str()));
     }
 
@@ -220,7 +237,10 @@ mod tests {
     async fn get_html_returns_404_when_data_missing() {
         let mut templates = HashMap::new();
         templates.insert("myapp/mytemplate".to_string(), SIMPLE_TEMPLATE.to_string());
-        let server = TestServer::new(make_router(make_state(templates, HashMap::new(), true), true));
+        let server = TestServer::new(make_router(
+            make_state(templates, HashMap::new(), true),
+            true,
+        ));
 
         let response = server.get("/myapp/mytemplate").await;
 

--- a/src/routes/nais.rs
+++ b/src/routes/nais.rs
@@ -51,10 +51,10 @@ mod tests {
     use axum_test::TestServer;
     use tokio::sync::RwLock;
 
+    use super::nais_router;
     use crate::config::Config;
     use crate::state::AppAliveness;
     use crate::{typst_world, AppState};
-    use super::nais_router;
 
     fn test_state(alive: bool, ready: bool) -> AppState {
         let aliveness = AppAliveness::new();

--- a/src/template.rs
+++ b/src/template.rs
@@ -108,7 +108,7 @@ pub fn load_test_data(data_dir: &Path) -> TestDataLoadResult {
         if !path.is_file() {
             continue;
         }
-        if path.extension().map_or(true, |ext| ext != "json") {
+        if path.extension().is_none_or(|ext| ext != "json") {
             continue;
         }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -72,8 +72,8 @@ pub fn load_templates_from_dir(templates_dir: &Path) -> anyhow::Result<HashMap<S
                         .with_extension("")
                         .to_string_lossy()
                         .replace('\\', "/");
-                    let source = std::fs::read_to_string(path)
-                        .context("Failed to read template file")?;
+                    let source =
+                        std::fs::read_to_string(path).context("Failed to read template file")?;
                     templates.insert(name, source);
                 }
             }
@@ -134,8 +134,8 @@ pub fn load_test_data(data_dir: &Path) -> TestDataLoadResult {
                 result.diagnostics.push(LoadDiagnostic {
                     path: path.to_path_buf(),
                     kind: LoadErrorKind::InvalidPath,
-                    message:
-                        "Expected file path format '<app_name>/<template_name>.json'".to_string(),
+                    message: "Expected file path format '<app_name>/<template_name>.json'"
+                        .to_string(),
                 });
                 continue;
             }
@@ -177,10 +177,9 @@ pub fn load_test_data(data_dir: &Path) -> TestDataLoadResult {
             }
         };
 
-        result.data.insert(
-            (app_name.to_string(), template_name.to_string()),
-            value,
-        );
+        result
+            .data
+            .insert((app_name.to_string(), template_name.to_string()), value);
     }
 
     result
@@ -213,7 +212,10 @@ mod tests {
         let templates = load_templates_from_dir(dir.path()).unwrap();
 
         assert_eq!(templates.len(), 1);
-        assert!(templates.contains_key("myapp/report"), "key should use forward slash");
+        assert!(
+            templates.contains_key("myapp/report"),
+            "key should use forward slash"
+        );
         assert_eq!(templates["myapp/report"], "Report content");
     }
 
@@ -283,7 +285,9 @@ mod tests {
         let result = load_test_data(dir.path());
 
         assert_eq!(result.data.len(), 1);
-        assert!(result.data.contains_key(&("myapp".to_string(), "valid".to_string())));
+        assert!(result
+            .data
+            .contains_key(&("myapp".to_string(), "valid".to_string())));
         assert_eq!(result.diagnostics.len(), 1);
         assert_eq!(result.diagnostics[0].kind, LoadErrorKind::InvalidJson);
 

--- a/src/tracing_setup.rs
+++ b/src/tracing_setup.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
+use opentelemetry::propagation::TextMapCompositePropagator;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::{global, KeyValue};
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
-use opentelemetry::propagation::TextMapCompositePropagator;
 use opentelemetry_sdk::{
     propagation::{BaggagePropagator, TraceContextPropagator},
     trace::Sampler,
@@ -88,16 +88,10 @@ where
         }
         impl tracing::field::Visit for FieldVisitor<'_> {
             fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-                self.map.insert(
-                    field.name().to_string(),
-                    Value::String(value.to_string()),
-                );
+                self.map
+                    .insert(field.name().to_string(), Value::String(value.to_string()));
             }
-            fn record_debug(
-                &mut self,
-                field: &tracing::field::Field,
-                value: &dyn std::fmt::Debug,
-            ) {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
                 self.map.insert(
                     field.name().to_string(),
                     Value::String(format!("{:?}", value)),
@@ -164,7 +158,8 @@ fn resolve_service_name(name: Option<&str>) -> String {
 /// Returns the `SdkTracerProvider` so the caller can call `.shutdown()` for a
 /// graceful flush before the process exits.
 pub fn setup_tracing() -> Result<opentelemetry_sdk::trace::SdkTracerProvider> {
-    let exporter = nais_otlp_exporter(std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok().as_deref())?;
+    let exporter =
+        nais_otlp_exporter(std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok().as_deref())?;
     let exporter_active = exporter.is_some();
 
     let builder = opentelemetry_sdk::trace::SdkTracerProvider::builder();
@@ -202,9 +197,7 @@ pub fn setup_tracing() -> Result<opentelemetry_sdk::trace::SdkTracerProvider> {
         Box::new(BaggagePropagator::new()),
     ]));
 
-    let fmt_layer = fmt::layer()
-        .event_format(NaisJsonFormat)
-        .with_ansi(false);
+    let fmt_layer = fmt::layer().event_format(NaisJsonFormat).with_ansi(false);
 
     let tracer = tracer_provider.tracer("pdfgenrs");
     // Keep a clone for the caller to shut down gracefully before exit.
@@ -213,10 +206,7 @@ pub fn setup_tracing() -> Result<opentelemetry_sdk::trace::SdkTracerProvider> {
     global::set_tracer_provider(tracer_provider);
 
     tracing_subscriber::registry()
-        .with(
-            EnvFilter::from_default_env()
-                .add_directive(tracing::Level::INFO.into()),
-        )
+        .with(EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()))
         .with(OpenTelemetryLayer::new(tracer))
         .with(fmt_layer)
         .init();
@@ -247,12 +237,18 @@ mod tests {
 
     #[test]
     fn logger_name_for_file_keeps_non_rs_suffix() {
-        assert_eq!(logger_name_for_file("src/tracing_setup"), "src.tracing_setup");
+        assert_eq!(
+            logger_name_for_file("src/tracing_setup"),
+            "src.tracing_setup"
+        );
     }
 
     #[test]
     fn resolve_service_name_uses_env_value() {
-        assert_eq!(resolve_service_name(Some("custom-service")), "custom-service");
+        assert_eq!(
+            resolve_service_name(Some("custom-service")),
+            "custom-service"
+        );
     }
 
     #[test]

--- a/src/typst_world.rs
+++ b/src/typst_world.rs
@@ -6,8 +6,8 @@ use anyhow::{Context, Result};
 use chrono::Datelike;
 use chrono::Timelike;
 use typst::foundations::Bytes;
-use typst::{Feature, Features, Library, LibraryExt};
 use typst::utils::LazyHash;
+use typst::{Feature, Features, Library, LibraryExt};
 use typst_library::diag::{FileError, FileResult};
 use typst_library::text::{Font, FontBook};
 use typst_library::World;
@@ -58,7 +58,10 @@ pub fn load_fonts(fonts_dir: &Path) -> Result<Fonts> {
     }
 
     let book = FontBook::from_fonts(&fonts);
-    Ok(Fonts { fonts, book: LazyHash::new(book) })
+    Ok(Fonts {
+        fonts,
+        book: LazyHash::new(book),
+    })
 }
 
 /// Recursively walks `dir` and appends all supported font files to `files`.
@@ -166,8 +169,8 @@ impl World for PdfgenWorld {
         }
         let vpath = id.vpath();
         let physical = self.root.join(vpath.as_rootless_path());
-        let text = std::fs::read_to_string(&physical)
-            .map_err(|e| FileError::from_io(e, &physical))?;
+        let text =
+            std::fs::read_to_string(&physical).map_err(|e| FileError::from_io(e, &physical))?;
         Ok(Source::new(id, text))
     }
 
@@ -177,8 +180,7 @@ impl World for PdfgenWorld {
         }
         let vpath = id.vpath();
         let physical = self.root.join(vpath.as_rootless_path());
-        let bytes = std::fs::read(&physical)
-            .map_err(|e| FileError::from_io(e, &physical))?;
+        let bytes = std::fs::read(&physical).map_err(|e| FileError::from_io(e, &physical))?;
         Ok(Bytes::new(bytes))
     }
 
@@ -218,24 +220,30 @@ pub fn compile_to_pdf(
     main_source: String,
     virtual_files: HashMap<String, Bytes>,
 ) -> Result<Vec<u8>> {
-    let world = PdfgenWorld::new(fonts, root, main_path, main_source, virtual_files, Features::default());
+    let world = PdfgenWorld::new(
+        fonts,
+        root,
+        main_path,
+        main_source,
+        virtual_files,
+        Features::default(),
+    );
 
     let result = typst::compile::<typst_library::layout::PagedDocument>(&world);
 
     comemo::evict(15);
 
-    let document = result
-        .output
-        .map_err(|errors| {
-            let msgs: Vec<String> = errors
-                .iter()
-                .map(|e| e.message.to_string())
-                .collect();
-            anyhow::anyhow!("Typst compilation failed: {}", msgs.join("; "))
-        })?;
+    let document = result.output.map_err(|errors| {
+        let msgs: Vec<String> = errors.iter().map(|e| e.message.to_string()).collect();
+        anyhow::anyhow!("Typst compilation failed: {}", msgs.join("; "))
+    })?;
 
     if !result.warnings.is_empty() {
-        let warns: Vec<String> = result.warnings.iter().map(|w| w.message.to_string()).collect();
+        let warns: Vec<String> = result
+            .warnings
+            .iter()
+            .map(|w| w.message.to_string())
+            .collect();
         tracing::warn!(warnings = warns.join("; "), "Typst compilation warnings");
     }
 
@@ -248,11 +256,10 @@ pub fn compile_to_pdf(
         timestamp,
         ..typst_pdf::PdfOptions::default()
     };
-    let pdf_bytes = typst_pdf::pdf(&document, &options)
-        .map_err(|errors| {
-            let msgs: Vec<String> = errors.iter().map(|e| e.message.to_string()).collect();
-            anyhow::anyhow!("Typst PDF export failed: {}", msgs.join("; "))
-        })?;
+    let pdf_bytes = typst_pdf::pdf(&document, &options).map_err(|errors| {
+        let msgs: Vec<String> = errors.iter().map(|e| e.message.to_string()).collect();
+        anyhow::anyhow!("Typst PDF export failed: {}", msgs.join("; "))
+    })?;
 
     Ok(pdf_bytes)
 }
@@ -284,26 +291,24 @@ pub fn compile_to_html(
 
     comemo::evict(15);
 
-    let document = result
-        .output
-        .map_err(|errors| {
-            let msgs: Vec<String> = errors
-                .iter()
-                .map(|e| e.message.to_string())
-                .collect();
-            anyhow::anyhow!("Typst compilation failed: {}", msgs.join("; "))
-        })?;
+    let document = result.output.map_err(|errors| {
+        let msgs: Vec<String> = errors.iter().map(|e| e.message.to_string()).collect();
+        anyhow::anyhow!("Typst compilation failed: {}", msgs.join("; "))
+    })?;
 
     if !result.warnings.is_empty() {
-        let warns: Vec<String> = result.warnings.iter().map(|w| w.message.to_string()).collect();
+        let warns: Vec<String> = result
+            .warnings
+            .iter()
+            .map(|w| w.message.to_string())
+            .collect();
         tracing::warn!(warnings = warns.join("; "), "Typst compilation warnings");
     }
 
-    typst_html::html(&document)
-        .map_err(|errors| {
-            let msgs: Vec<String> = errors.iter().map(|e| e.message.to_string()).collect();
-            anyhow::anyhow!("Typst HTML export failed: {}", msgs.join("; "))
-        })
+    typst_html::html(&document).map_err(|errors| {
+        let msgs: Vec<String> = errors.iter().map(|e| e.message.to_string()).collect();
+        anyhow::anyhow!("Typst HTML export failed: {}", msgs.join("; "))
+    })
 }
 
 fn build_timestamp() -> Option<typst_pdf::Timestamp> {
@@ -343,7 +348,8 @@ mod tests {
 
     #[test]
     fn fonts_load_from_directory() {
-        let fonts = load_fonts(&root_dir().join("fonts")).expect("fonts should load from directory");
+        let fonts =
+            load_fonts(&root_dir().join("fonts")).expect("fonts should load from directory");
         assert!(
             !fonts.fonts.is_empty(),
             "Expected at least one font face loaded from fonts directory"
@@ -366,7 +372,11 @@ Hello, world!
             source.to_string(),
             HashMap::new(),
         );
-        assert!(result1.is_ok(), "First compilation failed: {:?}", result1.err());
+        assert!(
+            result1.is_ok(),
+            "First compilation failed: {:?}",
+            result1.err()
+        );
         let pdf1 = result1.unwrap();
         assert!(is_pdf(&pdf1), "First result is not a valid PDF");
 
@@ -377,7 +387,11 @@ Hello, world!
             source.to_string(),
             HashMap::new(),
         );
-        assert!(result2.is_ok(), "Second compilation failed: {:?}", result2.err());
+        assert!(
+            result2.is_ok(),
+            "Second compilation failed: {:?}",
+            result2.err()
+        );
         let pdf2 = result2.unwrap();
         assert!(is_pdf(&pdf2), "Second result is not a valid PDF");
     }
@@ -396,7 +410,10 @@ Hello, world!
             "Compilation after full cache eviction failed: {:?}",
             result.err()
         );
-        assert!(is_pdf(&result.unwrap()), "Result after cache eviction is not a valid PDF");
+        assert!(
+            is_pdf(&result.unwrap()),
+            "Result after cache eviction is not a valid PDF"
+        );
     }
 
     #[test]
@@ -407,8 +424,14 @@ Hello, world!
 
         for i in 0..10 {
             let source = format!("#set page(margin: 1cm)\nWarmup {i}.");
-            compile_to_pdf(Arc::clone(&fonts), &root, "/main.typ", source, HashMap::new())
-                .expect("warmup compilation should succeed");
+            compile_to_pdf(
+                Arc::clone(&fonts),
+                &root,
+                "/main.typ",
+                source,
+                HashMap::new(),
+            )
+            .expect("warmup compilation should succeed");
         }
 
         let Some(rss_before) = rss_kb() else {
@@ -417,8 +440,13 @@ Hello, world!
 
         for i in 0..200 {
             let source = format!("#set page(margin: 1cm)\nDocument {i} with unique content.");
-            let result =
-                compile_to_pdf(Arc::clone(&fonts), &root, "/main.typ", source, HashMap::new());
+            let result = compile_to_pdf(
+                Arc::clone(&fonts),
+                &root,
+                "/main.typ",
+                source,
+                HashMap::new(),
+            );
             assert!(result.is_ok(), "Compilation {i} failed: {:?}", result.err());
         }
 


### PR DESCRIPTION
Added lints for Rust and Clippy to warn on unsafe operations.