### PR TITLE
Add #[must_use] attribute to resource_root and font_dir

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -84,12 +84,14 @@ impl Config {
 
     /// Returns the absolute resource directory used to resolve `/resources/...` Typst paths.
     /// Relative paths in `resources_dir` are resolved from `root_dir`.
+    #[must_use]
     pub fn resource_root(&self) -> PathBuf {
         resolve_from_root(&self.root_dir, &self.resources_dir)
     }
 
     /// Returns the absolute font directory.
     /// Relative paths in `fonts_dir` are resolved from `root_dir`.
+    #[must_use]
     pub fn font_dir(&self) -> PathBuf {
         resolve_from_root(&self.root_dir, &self.fonts_dir)
     }


### PR DESCRIPTION
## Summary

Describe what this pull request changes and why.

## Checklist

- [ ] I have run `cargo fmt -- --check`
- [ ] I have run `cargo clippy --all-targets -- -D warnings`
- [ ] I have run `cargo test --release -- --nocapture`
- [ ] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [ ] I have updated tests where relevant
