### PR TITLE
chore: Simplify Docker image build and push process

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -7,7 +7,6 @@ permissions:
   contents: read
   id-token: write
   packages: write
-
 env:
   IMAGE: ghcr.io/${{ github.repository }}
   NEW_VERSION: ${{ github.event.release.tag_name }}
@@ -19,22 +18,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image to ghcr.io
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: ${{ env.IMAGE }}:${{ env.NEW_VERSION }}
+      - name: Build Docker image to ghcr.io
+        run: |
+          docker build --tag ${{ env.IMAGE }}:${{ env.NEW_VERSION }} .
+      - name: Push docker image to GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
+          docker push ${{ env.IMAGE }}:${{ env.NEW_VERSION }}


### PR DESCRIPTION
Replaced Docker Buildx setup with direct Docker commands for building and pushing the image.

## Summary

Describe what this pull request changes and why.

## Checklist

- [ ] I have run `cargo fmt -- --check`
- [ ] I have run `cargo clippy --all-targets -- -D warnings`
- [ ] I have run `cargo test --release -- --nocapture`
- [ ] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [ ] I have updated tests where relevant
