### PR TITLE
Add delay before marking service as not alive

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,7 @@ async fn main() -> Result<()> {
             if let Err(e) = shutdown_signal(aliveness_for_shutdown.clone()).await {
                 tracing::error!(error = %e, "Shutdown signal handler failed");
                 aliveness_for_shutdown.set_ready(false);
+                tokio::time::sleep(Duration::from_secs(5))
                 aliveness_for_shutdown.set_alive(false);
             }
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use pdfgenrs::metrics;
 use pdfgenrs::state::{AppAliveness, AppState};
 use pdfgenrs::{build_html_converter, build_router, config, template, typst_world};
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ async fn main() -> Result<()> {
             if let Err(e) = shutdown_signal(aliveness_for_shutdown.clone()).await {
                 tracing::error!(error = %e, "Shutdown signal handler failed");
                 aliveness_for_shutdown.set_ready(false);
-                tokio::time::sleep(Duration::from_secs(5))
+                tokio::time::sleep(Duration::from_secs(5));
                 aliveness_for_shutdown.set_alive(false);
             }
         })


### PR DESCRIPTION
Introduce a delay before setting the service to not alive after a shutdown signal.

## Summary

Describe what this pull request changes and why.

## Checklist

- [ ] I have run `cargo fmt -- --check`
- [ ] I have run `cargo clippy --all-targets -- -D warnings`
- [ ] I have run `cargo test --release -- --nocapture`
- [ ] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [ ] I have updated tests where relevant
