### PR TITLE
Add #[must_use] attribute to build_html_converter

### DIFF
--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -30,6 +30,7 @@ const HTML_FONT_ALIASES: &[(&str, &str)] = &[
 ///
 /// Returns a tuple of `(converter, count)` where `count` is the number of
 /// font aliases successfully loaded.
+#[must_use]
 pub fn build_html_converter(fonts_dir: &Path, base_path: &Path) -> (HtmlConverter, usize) {
     let mut converter = HtmlConverter::new().base_path(base_path);
     let mut count = 0;


### PR DESCRIPTION
## Summary

Describe what this pull request changes and why.

## Checklist

- [ ] I have run `cargo fmt -- --check`
- [ ] I have run `cargo clippy --all-targets -- -D warnings`
- [ ] I have run `cargo test --release -- --nocapture`
- [ ] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [ ] I have updated tests where relevant
