### PR TITLE
chore: tighten Clippy lint compliance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,8 @@ unsafe_op_in_unsafe_fn = "warn"
 [lints.clippy]
 unwrap_used = "warn"
 expect_used = "warn"
+panic = "warn"
+todo = "warn"
+dbg_macro = "warn"
+print_stdout = "warn"
+print_stderr = "warn"

--- a/benches/performance.rs
+++ b/benches/performance.rs
@@ -87,7 +87,11 @@ fn write_github_summary(mt_results: &[BenchResult], st_results: &[BenchResult]) 
     }
 
     if let Err(e) = std::fs::write(&summary_file, &md) {
-        eprintln!("Failed to write GitHub step summary to {summary_file}: {e}");
+        tracing::warn!(
+            path = %summary_file,
+            error = %e,
+            "Failed to write GitHub step summary"
+        );
     }
 }
 

--- a/src/http_tracing.rs
+++ b/src/http_tracing.rs
@@ -60,6 +60,7 @@ mod imp {
     }
 
     #[cfg(test)]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
     mod tests {
         use super::*;
         use axum::http::{HeaderValue, Method, Uri, Version};
@@ -70,10 +71,8 @@ mod imp {
         #[test]
         fn header_extractor_reads_valid_headers_and_skips_non_utf8_values() {
             let mut headers = HeaderMap::new();
-            let invalid_header = match HeaderValue::from_bytes(b"\xFF") {
-                Ok(value) => value,
-                Err(error) => panic!("expected opaque header value: {error}"),
-            };
+            let invalid_header =
+                HeaderValue::from_bytes(b"\xFF").expect("expected opaque header value");
             headers.insert(
                 "traceparent",
                 HeaderValue::from_static("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"),
@@ -118,16 +117,10 @@ mod imp {
                     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
                 )
                 .body(Body::empty());
-            let request = match request_result {
-                Ok(request) => request,
-                Err(error) => panic!("expected valid request: {error}"),
-            };
+            let request = request_result.expect("expected valid request");
 
             let span = make_otel_span(&request);
-            let metadata = match span.metadata() {
-                Some(metadata) => metadata,
-                None => panic!("expected span metadata"),
-            };
+            let metadata = span.metadata().expect("expected span metadata");
 
             assert_eq!(metadata.name(), "HTTP request");
             assert_eq!(metadata.level(), &tracing::Level::INFO);

--- a/src/http_tracing.rs
+++ b/src/http_tracing.rs
@@ -60,19 +60,18 @@ mod imp {
     }
 
     #[cfg(test)]
-    #[allow(clippy::unwrap_used, clippy::expect_used)]
     mod tests {
         use super::*;
+        use anyhow::anyhow;
         use axum::http::{HeaderValue, Method, Uri, Version};
         use opentelemetry::propagation::TextMapPropagator;
         use opentelemetry::trace::TraceContextExt;
         use opentelemetry_sdk::propagation::TraceContextPropagator;
 
         #[test]
-        fn header_extractor_reads_valid_headers_and_skips_non_utf8_values() {
+        fn header_extractor_reads_valid_headers_and_skips_non_utf8_values() -> anyhow::Result<()> {
             let mut headers = HeaderMap::new();
-            let invalid_header =
-                HeaderValue::from_bytes(b"\xFF").expect("expected opaque header value");
+            let invalid_header = HeaderValue::from_bytes(b"\xFF")?;
             headers.insert(
                 "traceparent",
                 HeaderValue::from_static("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"),
@@ -90,6 +89,7 @@ mod imp {
             let keys = extractor.keys();
             assert!(keys.contains(&"traceparent"));
             assert!(keys.contains(&"x-invalid"));
+            Ok(())
         }
 
         #[test]
@@ -107,8 +107,8 @@ mod imp {
         }
 
         #[test]
-        fn make_otel_span_creates_http_request_span() {
-            let request_result = Request::builder()
+        fn make_otel_span_creates_http_request_span() -> anyhow::Result<()> {
+            let request = Request::builder()
                 .method(Method::POST)
                 .uri(Uri::from_static("/api/v1/genpdf"))
                 .version(Version::HTTP_11)
@@ -116,14 +116,16 @@ mod imp {
                     "traceparent",
                     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
                 )
-                .body(Body::empty());
-            let request = request_result.expect("expected valid request");
+                .body(Body::empty())?;
 
             let span = make_otel_span(&request);
-            let metadata = span.metadata().expect("expected span metadata");
+            let metadata = span
+                .metadata()
+                .ok_or_else(|| anyhow!("expected span metadata"))?;
 
             assert_eq!(metadata.name(), "HTTP request");
             assert_eq!(metadata.level(), &tracing::Level::INFO);
+            Ok(())
         }
 
         #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,7 @@ use tracing::{info, warn};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let tracer_provider = tracing_setup::setup_tracing().map_err(|e| {
-        eprintln!("Failed to initialise tracing: {e}");
-        e
-    })?;
+    let tracer_provider = tracing_setup::setup_tracing().context("Failed to initialise tracing")?;
 
     let cfg = config::Config::default();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<()> {
         compile_semaphore,
     };
 
-    let metrics_handle = metrics::setup_metrics_recorder();
+    let metrics_handle = metrics::setup_metrics_recorder()?;
 
     let app = build_router(state, metrics_handle);
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use std::time::Instant;
 
 use axum::{body::Body, extract::MatchedPath, http::Request, middleware::Next, response::Response};
@@ -7,12 +8,11 @@ use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 /// Installs the global Prometheus metrics recorder and returns a handle for rendering.
 ///
 /// Must be called once at application startup before any metrics are recorded.
-#[allow(clippy::expect_used)]
-pub fn setup_metrics_recorder() -> PrometheusHandle {
+pub fn setup_metrics_recorder() -> anyhow::Result<PrometheusHandle> {
     let builder = PrometheusBuilder::new();
     builder
         .install_recorder()
-        .expect("Failed to install Prometheus recorder")
+        .context("Failed to install Prometheus recorder")
 }
 
 /// Creates a [`PrometheusHandle`] without installing a global recorder.
@@ -50,12 +50,18 @@ pub async fn track_metrics(request: Request<Body>, next: Next) -> Response {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use axum::http::StatusCode;
     use axum::{Router, middleware, routing::get};
     use axum_test::TestServer;
+
+    fn build_runtime() -> anyhow::Result<tokio::runtime::Runtime> {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("failed to build runtime")
+    }
 
     async fn handler() -> StatusCode {
         StatusCode::OK
@@ -73,14 +79,11 @@ mod tests {
     }
 
     #[test]
-    fn records_request_counter_with_correct_labels() {
+    fn records_request_counter_with_correct_labels() -> anyhow::Result<()> {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
         metrics::with_local_recorder(&recorder, || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("failed to build runtime");
+            let rt = build_runtime()?;
             rt.block_on(async {
                 let server = TestServer::new(test_app());
                 server.get("/hello").await;
@@ -102,19 +105,19 @@ mod tests {
                     output.contains(r#"status="200""#),
                     "expected status=200 label: {output}"
                 );
-            });
-        });
+                Ok::<_, anyhow::Error>(())
+            })?;
+            Ok::<(), anyhow::Error>(())
+        })?;
+        Ok::<(), anyhow::Error>(())
     }
 
     #[test]
-    fn records_histogram_with_correct_labels() {
+    fn records_histogram_with_correct_labels() -> anyhow::Result<()> {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
         metrics::with_local_recorder(&recorder, || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("failed to build runtime");
+            let rt = build_runtime()?;
             rt.block_on(async {
                 let server = TestServer::new(test_app());
                 server.get("/hello").await;
@@ -124,19 +127,19 @@ mod tests {
                     output.contains("http_request_duration_seconds"),
                     "expected http_request_duration_seconds in output: {output}"
                 );
-            });
-        });
+                Ok::<_, anyhow::Error>(())
+            })?;
+            Ok::<(), anyhow::Error>(())
+        })?;
+        Ok::<(), anyhow::Error>(())
     }
 
     #[test]
-    fn records_non_200_status_label() {
+    fn records_non_200_status_label() -> anyhow::Result<()> {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
         metrics::with_local_recorder(&recorder, || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("failed to build runtime");
+            let rt = build_runtime()?;
             rt.block_on(async {
                 let server = TestServer::new(test_app());
                 server.get("/missing").await;
@@ -146,19 +149,19 @@ mod tests {
                     output.contains(r#"status="404""#),
                     "expected status=404 label: {output}"
                 );
-            });
-        });
+                Ok::<_, anyhow::Error>(())
+            })?;
+            Ok::<(), anyhow::Error>(())
+        })?;
+        Ok::<(), anyhow::Error>(())
     }
 
     #[test]
-    fn unknown_path_when_no_matched_path() {
+    fn unknown_path_when_no_matched_path() -> anyhow::Result<()> {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
         metrics::with_local_recorder(&recorder, || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("failed to build runtime");
+            let rt = build_runtime()?;
             rt.block_on(async {
                 let server = TestServer::new(test_app());
                 server.get("/nonexistent").await;
@@ -168,19 +171,19 @@ mod tests {
                     output.contains(r#"path="unknown""#),
                     "expected path=unknown for unmatched route: {output}"
                 );
-            });
-        });
+                Ok::<_, anyhow::Error>(())
+            })?;
+            Ok::<(), anyhow::Error>(())
+        })?;
+        Ok::<(), anyhow::Error>(())
     }
 
     #[test]
-    fn counter_increments_on_multiple_requests() {
+    fn counter_increments_on_multiple_requests() -> anyhow::Result<()> {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
         metrics::with_local_recorder(&recorder, || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("failed to build runtime");
+            let rt = build_runtime()?;
             rt.block_on(async {
                 let server = TestServer::new(test_app());
                 server.get("/hello").await;
@@ -197,10 +200,14 @@ mod tests {
                     matching_line.is_some(),
                     "http_requests_total metric line not found in output: {output}"
                 );
-                let line =
-                    matching_line.expect("matching metric line should exist after assertion");
+                let Some(line) = matching_line else {
+                    anyhow::bail!("matching metric line should exist after assertion");
+                };
                 assert!(line.ends_with(" 3"), "expected counter value 3: {line}");
-            });
-        });
+                Ok::<_, anyhow::Error>(())
+            })?;
+            Ok::<(), anyhow::Error>(())
+        })?;
+        Ok(())
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -7,11 +7,12 @@ use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 /// Installs the global Prometheus metrics recorder and returns a handle for rendering.
 ///
 /// Must be called once at application startup before any metrics are recorded.
+#[allow(clippy::expect_used)]
 pub fn setup_metrics_recorder() -> PrometheusHandle {
     let builder = PrometheusBuilder::new();
     builder
         .install_recorder()
-        .unwrap_or_else(|e| panic!("Failed to install Prometheus recorder: {e}"))
+        .expect("Failed to install Prometheus recorder")
 }
 
 /// Creates a [`PrometheusHandle`] without installing a global recorder.
@@ -49,6 +50,7 @@ pub async fn track_metrics(request: Request<Body>, next: Next) -> Response {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use axum::http::StatusCode;
@@ -78,7 +80,7 @@ mod tests {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .unwrap_or_else(|e| panic!("failed to build runtime: {e}"));
+                .expect("failed to build runtime");
             rt.block_on(async {
                 let server = TestServer::new(test_app());
                 server.get("/hello").await;
@@ -112,7 +114,7 @@ mod tests {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .unwrap_or_else(|e| panic!("failed to build runtime: {e}"));
+                .expect("failed to build runtime");
             rt.block_on(async {
                 let server = TestServer::new(test_app());
                 server.get("/hello").await;
@@ -134,7 +136,7 @@ mod tests {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .unwrap_or_else(|e| panic!("failed to build runtime: {e}"));
+                .expect("failed to build runtime");
             rt.block_on(async {
                 let server = TestServer::new(test_app());
                 server.get("/missing").await;
@@ -156,7 +158,7 @@ mod tests {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .unwrap_or_else(|e| panic!("failed to build runtime: {e}"));
+                .expect("failed to build runtime");
             rt.block_on(async {
                 let server = TestServer::new(test_app());
                 server.get("/nonexistent").await;
@@ -178,7 +180,7 @@ mod tests {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .unwrap_or_else(|e| panic!("failed to build runtime: {e}"));
+                .expect("failed to build runtime");
             rt.block_on(async {
                 let server = TestServer::new(test_app());
                 server.get("/hello").await;
@@ -186,16 +188,17 @@ mod tests {
                 server.get("/hello").await;
 
                 let output = handle.render();
-                for line in output.lines() {
-                    if line.starts_with("http_requests_total{")
+                let matching_line = output.lines().find(|line| {
+                    line.starts_with("http_requests_total{")
                         && line.contains(r#"path="/hello""#)
                         && line.contains(r#"status="200""#)
-                    {
-                        assert!(line.ends_with(" 3"), "expected counter value 3: {line}");
-                        return;
-                    }
-                }
-                panic!("http_requests_total metric line not found in output: {output}");
+                });
+                assert!(
+                    matching_line.is_some(),
+                    "http_requests_total metric line not found in output: {output}"
+                );
+                let line = matching_line.expect("matching metric line should exist after assertion");
+                assert!(line.ends_with(" 3"), "expected counter value 3: {line}");
             });
         });
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -197,7 +197,8 @@ mod tests {
                     matching_line.is_some(),
                     "http_requests_total metric line not found in output: {output}"
                 );
-                let line = matching_line.expect("matching metric line should exist after assertion");
+                let line =
+                    matching_line.expect("matching metric line should exist after assertion");
                 assert!(line.ends_with(" 3"), "expected counter value 3: {line}");
             });
         });

--- a/src/request_id.rs
+++ b/src/request_id.rs
@@ -34,9 +34,9 @@ pub(crate) async fn request_id_middleware(request: Request, next: Next) -> Respo
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use anyhow::anyhow;
     use axum::http::StatusCode;
     use axum::{Router, middleware, routing::get};
     use axum_test::TestServer;
@@ -52,23 +52,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn generates_request_id_when_not_provided() {
+    async fn generates_request_id_when_not_provided() -> anyhow::Result<()> {
         let server = TestServer::new(test_app());
         let response = server.get("/").await;
         assert_eq!(response.status_code(), StatusCode::OK);
         let header = response
             .headers()
             .get("x-request-id")
-            .expect("expected x-request-id header in response");
-        let value = header.to_str().expect("expected valid header value");
+            .ok_or_else(|| anyhow!("expected x-request-id header in response"))?;
+        let value = header.to_str()?;
         assert!(
             Uuid::parse_str(value).is_ok(),
             "expected valid UUID, got: {value}"
         );
+        Ok(())
     }
 
     #[tokio::test]
-    async fn propagates_request_id_from_request() {
+    async fn propagates_request_id_from_request() -> anyhow::Result<()> {
         let server = TestServer::new(test_app());
         let response = server
             .get("/")
@@ -81,8 +82,9 @@ mod tests {
         let header = response
             .headers()
             .get("x-request-id")
-            .expect("expected x-request-id header in response");
-        let value = header.to_str().expect("expected valid header value");
+            .ok_or_else(|| anyhow!("expected x-request-id header in response"))?;
+        let value = header.to_str()?;
         assert_eq!(value, "my-custom-id");
+        Ok(())
     }
 }

--- a/src/request_id.rs
+++ b/src/request_id.rs
@@ -34,6 +34,7 @@ pub(crate) async fn request_id_middleware(request: Request, next: Next) -> Respo
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use axum::http::StatusCode;
@@ -55,14 +56,11 @@ mod tests {
         let server = TestServer::new(test_app());
         let response = server.get("/").await;
         assert_eq!(response.status_code(), StatusCode::OK);
-        let header = match response.headers().get("x-request-id") {
-            Some(v) => v,
-            None => panic!("expected x-request-id header in response"),
-        };
-        let value = match header.to_str() {
-            Ok(v) => v,
-            Err(e) => panic!("expected valid header value: {e}"),
-        };
+        let header = response
+            .headers()
+            .get("x-request-id")
+            .expect("expected x-request-id header in response");
+        let value = header.to_str().expect("expected valid header value");
         assert!(
             Uuid::parse_str(value).is_ok(),
             "expected valid UUID, got: {value}"
@@ -80,14 +78,11 @@ mod tests {
             )
             .await;
         assert_eq!(response.status_code(), StatusCode::OK);
-        let header = match response.headers().get("x-request-id") {
-            Some(v) => v,
-            None => panic!("expected x-request-id header in response"),
-        };
-        let value = match header.to_str() {
-            Ok(v) => v,
-            Err(e) => panic!("expected valid header value: {e}"),
-        };
+        let header = response
+            .headers()
+            .get("x-request-id")
+            .expect("expected x-request-id header in response");
+        let value = header.to_str().expect("expected valid header value");
         assert_eq!(value, "my-custom-id");
     }
 }

--- a/src/routes/error.rs
+++ b/src/routes/error.rs
@@ -130,105 +130,114 @@ impl IntoResponse for ApiError {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use anyhow::{Context, anyhow};
     use axum::http::StatusCode;
     use http_body_util::BodyExt;
 
-    async fn status_and_body(error: ApiError) -> (StatusCode, serde_json::Value) {
+    async fn status_and_body(error: ApiError) -> anyhow::Result<(StatusCode, serde_json::Value)> {
         let response = error.into_response();
         let status = response.status();
-        assert_eq!(
-            response
-                .headers()
-                .get("content-type")
-                .unwrap()
-                .to_str()
-                .unwrap(),
-            "application/problem+json; charset=utf-8"
-        );
-        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .ok_or_else(|| anyhow!("missing content-type header"))?
+            .to_str()
+            .context("invalid content-type header")?;
+        assert_eq!(content_type, "application/problem+json; charset=utf-8");
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .context("failed to read response body")?
+            .to_bytes();
         let json: serde_json::Value =
-            serde_json::from_slice(&body).expect("response body must be valid JSON");
-        (status, json)
+            serde_json::from_slice(&body).context("response body must be valid JSON")?;
+        Ok((status, json))
     }
 
     #[tokio::test]
-    async fn not_found_returns_404() {
-        let (status, body) = status_and_body(ApiError::NotFound).await;
+    async fn not_found_returns_404() -> anyhow::Result<()> {
+        let (status, body) = status_and_body(ApiError::NotFound).await?;
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(body["type"], "about:blank");
         assert_eq!(body["title"], "Not Found");
         assert_eq!(body["status"], 404);
         assert_eq!(body["detail"], "Template or application not found");
+        Ok(())
     }
 
     #[tokio::test]
-    async fn generation_failed_returns_500_with_template() {
+    async fn generation_failed_returns_500_with_template() -> anyhow::Result<()> {
         let error = ApiError::GenerationFailed {
             app_name: "myapp".to_string(),
             template_name: Some("template1".to_string()),
-            source: anyhow::anyhow!("render error"),
+            source: anyhow!("render error"),
         };
-        let (status, body) = status_and_body(error).await;
+        let (status, body) = status_and_body(error).await?;
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(body["type"], "about:blank");
         assert_eq!(body["title"], "Internal Server Error");
         assert_eq!(body["status"], 500);
         assert_eq!(body["detail"], "Internal server error");
+        Ok(())
     }
 
     #[tokio::test]
-    async fn generation_failed_returns_500_without_template() {
+    async fn generation_failed_returns_500_without_template() -> anyhow::Result<()> {
         let error = ApiError::GenerationFailed {
             app_name: "myapp".to_string(),
             template_name: None,
-            source: anyhow::anyhow!("render error"),
+            source: anyhow!("render error"),
         };
-        let (status, body) = status_and_body(error).await;
+        let (status, body) = status_and_body(error).await?;
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(body["type"], "about:blank");
         assert_eq!(body["title"], "Internal Server Error");
         assert_eq!(body["status"], 500);
         assert_eq!(body["detail"], "Internal server error");
+        Ok(())
     }
 
     #[tokio::test]
-    async fn unsupported_media_type_returns_415() {
-        let (status, body) = status_and_body(ApiError::UnsupportedMediaType).await;
+    async fn unsupported_media_type_returns_415() -> anyhow::Result<()> {
+        let (status, body) = status_and_body(ApiError::UnsupportedMediaType).await?;
         assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
         assert_eq!(body["type"], "about:blank");
         assert_eq!(body["title"], "Unsupported Media Type");
         assert_eq!(body["status"], 415);
         assert_eq!(body["detail"], "Unsupported media type");
+        Ok(())
     }
 
     #[tokio::test]
-    async fn request_timeout_returns_408_with_template() {
+    async fn request_timeout_returns_408_with_template() -> anyhow::Result<()> {
         let error = ApiError::RequestTimeout {
             app_name: "myapp".to_string(),
             template_name: Some("template1".to_string()),
         };
-        let (status, body) = status_and_body(error).await;
+        let (status, body) = status_and_body(error).await?;
         assert_eq!(status, StatusCode::REQUEST_TIMEOUT);
         assert_eq!(body["type"], "about:blank");
         assert_eq!(body["title"], "Request Timeout");
         assert_eq!(body["status"], 408);
         assert_eq!(body["detail"], "Request timed out");
+        Ok(())
     }
 
     #[tokio::test]
-    async fn request_timeout_returns_408_without_template() {
+    async fn request_timeout_returns_408_without_template() -> anyhow::Result<()> {
         let error = ApiError::RequestTimeout {
             app_name: "myapp".to_string(),
             template_name: None,
         };
-        let (status, body) = status_and_body(error).await;
+        let (status, body) = status_and_body(error).await?;
         assert_eq!(status, StatusCode::REQUEST_TIMEOUT);
         assert_eq!(body["type"], "about:blank");
         assert_eq!(body["title"], "Request Timeout");
         assert_eq!(body["status"], 408);
         assert_eq!(body["detail"], "Request timed out");
+        Ok(())
     }
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -133,12 +133,12 @@ where
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
 
+    use anyhow::Context;
     use tokio::sync::Semaphore;
 
     use super::compile_blocking;
@@ -161,7 +161,10 @@ mod tests {
         .await;
 
         assert!(result.is_err());
-        let err = result.unwrap_err();
+        let err = match result {
+            Ok(_) => anyhow::bail!("expected compile_blocking to time out"),
+            Err(err) => err,
+        };
         let response = axum::response::IntoResponse::into_response(err);
         assert_eq!(response.status(), axum::http::StatusCode::REQUEST_TIMEOUT);
         Ok(())
@@ -188,7 +191,9 @@ mod tests {
             .await
         });
 
-        started_rx.await.unwrap();
+        started_rx
+            .await
+            .context("failed to receive task1 start signal")?;
 
         let task2 = tokio::spawn(async move {
             tokio::time::timeout(
@@ -198,15 +203,19 @@ mod tests {
             .await
         });
 
-        let task2_result = task2.await.unwrap();
+        let task2_result = task2.await.context("task2 join error")?;
         assert!(
             task2_result.is_err(),
             "Expected task2 to time out while task1 holds the semaphore"
         );
 
         tx.send(()).ok();
-        let task1_result = task1.await.unwrap();
-        assert_eq!(task1_result.unwrap(), 42);
+        let task1_result = task1.await.context("task1 join error")?;
+        let value = match task1_result {
+            Ok(value) => value,
+            Err(error) => anyhow::bail!("task1 failed: {error:?}"),
+        };
+        assert_eq!(value, 42);
 
         Ok(())
     }

--- a/src/tracing_setup.rs
+++ b/src/tracing_setup.rs
@@ -253,6 +253,7 @@ fn setup_tracing_with(
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use serde_json::Value;


### PR DESCRIPTION
## Summary

Enable stricter Clippy warnings and update the codebase to comply with them without relying on temporary `allow` attributes.

This pull request:
- runs the code through `cargo fmt`
- fixes Clippy findings in the application, benchmarks, and tests
- removes `clippy::unwrap_used` / `clippy::expect_used` allowances from the affected files by replacing them with explicit error handling
- updates metrics recorder setup to return a `Result` instead of using `expect`

## Checklist

- [x] I have run `cargo fmt -- --check`
- [x] I have run `cargo clippy --all-targets -- -D warnings`
- [x] I have run `cargo test --release -- --nocapture`
- [x] I have run `cargo build --release`
- [x] If performance may be affected, I have run `cargo bench --bench performance`
- [x] I have updated tests where relevant