### PR TITLE
Remove obsolete font aliases from HTML_FONT_ALIASES

### DIFF
--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -9,9 +9,6 @@ use typst::foundations::Bytes;
 use crate::typst_world::{self, Fonts};
 
 const HTML_FONT_ALIASES: &[(&str, &str)] = &[
-    ("Source Sans Pro", "SourceSans3-Regular.ttf"),
-    ("Source Sans Pro__bold", "SourceSans3-Bold.ttf"),
-    ("Source Sans Pro__italic", "SourceSans3-Italic.ttf"),
     ("Source Sans 3", "SourceSans3-Regular.ttf"),
     ("Source Sans 3__bold", "SourceSans3-Bold.ttf"),
     ("Source Sans 3__italic", "SourceSans3-Italic.ttf"),


### PR DESCRIPTION
Removed deprecated font aliases for 'Source Sans Pro'.

## Summary

Describe what this pull request changes and why.

## Checklist

- [ ] I have run `cargo fmt -- --check`
- [ ] I have run `cargo clippy --all-targets -- -D warnings`
- [ ] I have run `cargo test --release -- --nocapture`
- [ ] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [ ] I have updated tests where relevant
