### PR TITLE
Update Rust version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pdfgenrs"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.96.0"
 description = "Library written in Rust used to create PDFs through an API"
 license = "MIT"
 repository = "https://github.com/navikt/pdfgenrs"


### PR DESCRIPTION
Updated the Rust version requirement from 1.90.0 to 1.96.0.

## Summary

Describe what this pull request changes and why.

## Checklist

- [ ] I have run `cargo fmt -- --check`
- [ ] I have run `cargo clippy --all-targets -- -D warnings`
- [ ] I have run `cargo test --release -- --nocapture`
- [ ] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [ ] I have updated tests where relevant
