### PR TITLE
chore: Add more lint warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,13 @@ tempfile = "3.27.0"
 
 [lints.rust]
 unsafe_op_in_unsafe_fn = "warn"
+elided_lifetimes_in_paths = "warn"
+missing_debug_implementations = "warn"
+single_use_lifetimes = "warn"
+trivial_numeric_casts = "warn"
+unused_lifetimes = "warn"
+unused_qualifications = "warn"
+unreachable_pub = "warn"
 
 [lints.clippy]
 unwrap_used = "warn"

--- a/src/html.rs
+++ b/src/html.rs
@@ -15,7 +15,7 @@ use crate::typst_world::{self, Fonts};
 /// # Errors
 /// Returns an error if serialisation of `json_data` fails or if the Typst
 /// compilation / HTML export fails.
-pub fn typst_to_html(
+pub(crate) fn typst_to_html(
     template_source: String,
     json_data: &serde_json::Value,
     fonts: Arc<Fonts>,

--- a/src/http_tracing.rs
+++ b/src/http_tracing.rs
@@ -17,7 +17,7 @@ mod imp {
     /// from request headers.
     struct HeaderExtractor<'a>(&'a HeaderMap);
 
-    impl<'a> Extractor for HeaderExtractor<'a> {
+    impl Extractor for HeaderExtractor<'_> {
         fn get(&self, key: &str) -> Option<&str> {
             self.0.get(key).and_then(|v| v.to_str().ok())
         }

--- a/src/routes/error.rs
+++ b/src/routes/error.rs
@@ -13,7 +13,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 ///
 /// Responses use the [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem
 /// Details format (`application/problem+json`).
-pub enum ApiError {
+pub(crate) enum ApiError {
     /// The requested template or application was not found.
     NotFound,
     /// An internal error occurred during document generation.

--- a/src/routes/html.rs
+++ b/src/routes/html.rs
@@ -19,7 +19,7 @@ use crate::state::AppState;
 /// Looks up the template source and preloaded test JSON data for the given
 /// `app_name` / `template` combination and returns an HTML response.
 /// Returns `404` if the template or its test data cannot be found.
-pub async fn get_html(
+pub(crate) async fn get_html(
     State(state): State<AppState>,
     Path((app_name, template_name)): Path<(String, String)>,
 ) -> Result<Response, ApiError> {
@@ -55,7 +55,7 @@ pub async fn get_html(
 /// Accepts a JSON body and compiles the named Typst template with that data,
 /// returning the result as `text/html`.
 /// Returns `404` if the template is not found, or `500` if compilation fails.
-pub async fn post_html(
+pub(crate) async fn post_html(
     State(state): State<AppState>,
     Path((app_name, template_name)): Path<(String, String)>,
     Json(json_data): Json<Value>,

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -10,10 +10,10 @@ use self::error::ApiError;
 use crate::state::AppState;
 use crate::typst_world::Fonts;
 
-pub mod error;
-pub mod html;
-pub mod nais;
-pub mod pdf;
+pub(crate) mod error;
+pub(crate) mod html;
+pub(crate) mod nais;
+pub(crate) mod pdf;
 
 /// Common parameters extracted from state for template compilation.
 pub(crate) struct CompileParams {

--- a/src/routes/nais.rs
+++ b/src/routes/nais.rs
@@ -11,7 +11,7 @@ use crate::state::AppState;
 
 /// Builds the NAIS health check router with `/internal/is_alive`,
 /// `/internal/is_ready`, and `/internal/metrics` endpoints.
-pub fn nais_router(metrics_handle: PrometheusHandle) -> Router<AppState> {
+pub(crate) fn nais_router(metrics_handle: PrometheusHandle) -> Router<AppState> {
     Router::new()
         .route("/internal/is_alive", get(is_alive))
         .route("/internal/is_ready", get(is_ready))
@@ -24,7 +24,7 @@ pub fn nais_router(metrics_handle: PrometheusHandle) -> Router<AppState> {
 /// Handles `GET /internal/is_alive`.
 ///
 /// Returns 200 OK when the application is alive, or 503 Service Unavailable otherwise.
-pub async fn is_alive(State(state): State<AppState>) -> Response {
+pub(crate) async fn is_alive(State(state): State<AppState>) -> Response {
     if state.aliveness.is_alive() {
         (StatusCode::OK, "I'm alive").into_response()
     } else {
@@ -36,7 +36,7 @@ pub async fn is_alive(State(state): State<AppState>) -> Response {
 ///
 /// Returns 200 OK when the application is ready to serve traffic, or 503 Service Unavailable otherwise.
 /// In addition to the readiness flag, verifies that templates were successfully loaded.
-pub async fn is_ready(State(state): State<AppState>) -> Response {
+pub(crate) async fn is_ready(State(state): State<AppState>) -> Response {
     if !state.aliveness.is_ready() {
         return (
             StatusCode::SERVICE_UNAVAILABLE,

--- a/src/routes/pdf.rs
+++ b/src/routes/pdf.rs
@@ -19,7 +19,7 @@ use crate::state::AppState;
 /// Looks up the template source and pre-loaded test JSON data for the given
 /// `app_name` / `template` combination and returns a PDF response.
 /// Returns `404` if the template or its test data cannot be found.
-pub async fn get_pdf(
+pub(crate) async fn get_pdf(
     State(state): State<AppState>,
     Path((app_name, template_name)): Path<(String, String)>,
 ) -> Result<Response, ApiError> {
@@ -55,7 +55,7 @@ pub async fn get_pdf(
 /// Accepts a JSON body and compiles the named Typst template with that data,
 /// returning the result as `application/pdf`.
 /// Returns `404` if the template is not found, or `500` if compilation fails.
-pub async fn post_pdf(
+pub(crate) async fn post_pdf(
     State(state): State<AppState>,
     Path((app_name, template_name)): Path<(String, String)>,
     Json(json_data): Json<Value>,
@@ -90,7 +90,7 @@ pub async fn post_pdf(
 /// Handles `POST /api/v1/genpdf/html/{app_name}`.
 ///
 /// Accepts an HTML body and converts it to PDF.
-pub async fn post_pdf_from_html(
+pub(crate) async fn post_pdf_from_html(
     State(state): State<AppState>,
     Path(app_name): Path<String>,
     html: String,
@@ -110,7 +110,7 @@ pub async fn post_pdf_from_html(
 /// Handles `POST /api/v1/genpdf/image/{app_name}`.
 ///
 /// Accepts a PNG or JPEG body and converts it to PDF.
-pub async fn post_pdf_from_image(
+pub(crate) async fn post_pdf_from_image(
     State(state): State<AppState>,
     Path(app_name): Path<String>,
     headers: HeaderMap,

--- a/src/state.rs
+++ b/src/state.rs
@@ -36,7 +36,7 @@ pub struct AppState {
 ///
 /// Both flags are stored as atomic booleans and can be shared across threads
 /// via [`Clone`]. Cloning this struct creates a new handle to the same shared state.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct AppAliveness {
     /// Whether the application process is alive (i.e. not shutting down).
     alive: Arc<AtomicBool>,
@@ -70,6 +70,22 @@ impl AppAliveness {
     #[inline]
     pub fn is_ready(&self) -> bool {
         self.ready.load(Ordering::Relaxed)
+    }
+}
+
+impl std::fmt::Debug for AppState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppState")
+            .field("templates", &self.templates)
+            .field("data", &self.data)
+            .field("aliveness", &self.aliveness)
+            .field("config", &self.config)
+            .field("fonts", &self.fonts)
+            .field("html_converter", &"HtmlConverter")
+            .field("compile_semaphore", &self.compile_semaphore)
+            .field("root_dir", &self.root_dir)
+            .field("resources_dir", &self.resources_dir)
+            .finish()
     }
 }
 

--- a/src/tracing_setup.rs
+++ b/src/tracing_setup.rs
@@ -177,7 +177,7 @@ fn resolve_service_name(name: Option<&str>) -> String {
 ///
 /// Returns the `SdkTracerProvider` so the caller can call `.shutdown()` for a
 /// graceful flush before the process exits.
-pub fn setup_tracing() -> Result<opentelemetry_sdk::trace::SdkTracerProvider> {
+pub(crate) fn setup_tracing() -> Result<opentelemetry_sdk::trace::SdkTracerProvider> {
     setup_tracing_with(
         std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok().as_deref(),
         std::env::var("OTEL_SERVICE_NAME").ok().as_deref(),

--- a/src/typst_world.rs
+++ b/src/typst_world.rs
@@ -112,6 +112,29 @@ pub struct PdfgenWorld {
     resources_dir: PathBuf,
 }
 
+impl std::fmt::Debug for Fonts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Fonts")
+            .field("fonts", &self.fonts.len())
+            .field("book", &self.book)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for PdfgenWorld {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PdfgenWorld")
+            .field("library", &self.library)
+            .field("fonts", &self.fonts)
+            .field("main_id", &self.main_id)
+            .field("main_source", &self.main_source)
+            .field("virtual_files", &self.virtual_files)
+            .field("root", &self.root)
+            .field("resources_dir", &self.resources_dir)
+            .finish()
+    }
+}
+
 impl PdfgenWorld {
     /// Creates a new `PdfgenWorld`.
     ///


### PR DESCRIPTION
Added additional lint warnings to Rust configuration.

## Summary

Describe what this pull request changes and why.

## Checklist

- [ ] I have run `cargo fmt -- --check`
- [ ] I have run `cargo clippy --all-targets -- -D warnings`
- [ ] I have run `cargo test --release -- --nocapture`
- [ ] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [ ] I have updated tests where relevant
