### PR TITLE
Add new lints for panic_in_result_fn and cognitive_complexity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ trivial_numeric_casts = "warn"
 unused_lifetimes = "warn"
 unused_qualifications = "warn"
 unreachable_pub = "warn"
+panic_in_result_fn = "warn"
+inefficient_to_string = "warn"
+cognitive_complexity = "warn"
 
 [lints.clippy]
 unwrap_used = "warn"


### PR DESCRIPTION
## Summary

Describe what this pull request changes and why.

## Checklist

- [ ] I have run `cargo fmt -- --check`
- [ ] I have run `cargo clippy --all-targets -- -D warnings`
- [ ] I have run `cargo test --release -- --nocapture`
- [ ] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [ ] I have updated tests where relevant
