### PR TITLE
Use the "preserve_order" feature of serde_json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3705,6 +3705,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ harness = false
 [dependencies]
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "sync", "net", "signal"] }
 axum = "0.8.9"
-serde_json = "1.0.150"
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
 time = { version = "0.3.51", features = ["local-offset", "formatting"] }
 walkdir = "2.5.0"
 anyhow = "1.0.102"


### PR DESCRIPTION
## Summary

Currently, the JSON log events produced by pdfgenrs gets their fields serialized in alphabetical order.  As the exact set of fields vary from event to event, this makes the log somewhat hard to scan.

By switching to "preserve_order" mode, I'm hoping that it will be a little easier to home in on interesting log lines.

## Checklist

- [x] I have run `cargo fmt -- --check`
- [x] I have run `cargo clippy --all-targets -- -D warnings`
- [x] I have run `cargo test --release -- --nocapture`
- [x] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [ ] I have updated tests where relevant
