### PR TITLE
Disable axum's implicit DefaultBodyLimit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub(crate) mod routes;
 #[doc(hidden)]
 pub mod testutil;
 
+use axum::extract::DefaultBodyLimit;
 use axum::{
     Router,
     extract::State,
@@ -73,6 +74,7 @@ pub fn build_router(state: AppState, metrics_handle: PrometheusHandle) -> Router
         .merge(routes::nais::nais_router(metrics_handle))
         .layer(middleware::from_fn(request_id::request_id_middleware))
         .layer(middleware::from_fn(metrics::track_metrics))
+        .layer(DefaultBodyLimit::disable())
         .layer(RequestBodyLimitLayer::new(request_body_limit_bytes))
         .with_state(state)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -621,7 +621,9 @@ Dev mode: #data.at("mode", default: "unknown")
     async fn build_router_enforces_custom_request_body_limit() -> anyhow::Result<()> {
         use pdfgenrs::testutil::make_state_with_body_limit;
 
-        let custom_limit: usize = 1024; // 1 KiB
+        // Set limit slightly over axum's implicit DefaultBodyLimit of 2MB
+        // (see https://docs.rs/axum/latest/axum/extract/struct.DefaultBodyLimit.html)
+        let custom_limit: usize = 1024 + 2 * 1024 * 1024;
         let state =
             make_state_with_body_limit(HashMap::new(), HashMap::new(), false, custom_limit)?;
         let server = TestServer::new(build_router(state, metrics::test_metrics_handle()));
@@ -637,7 +639,7 @@ Dev mode: #data.at("mode", default: "unknown")
 
         // A request body within the custom limit should NOT be rejected as too large.
         // (It may fail for other reasons, e.g. template not found, but not 413.)
-        let within_limit = r#"{"data":"ok"}"#;
+        let within_limit = format!(r#"{{"data":"{}"}}"#, "x".repeat(custom_limit - 100));
         let response = server
             .post("/api/v1/genpdf/myapp/mytemplate")
             .content_type("application/json")


### PR DESCRIPTION
## Summary

In order to allow increasing the request body size limit above the default of 2 MiB (e.g. by using the env var ´REQUEST_BODY_LIMIT_BYTES´), axum's implicit `DefaultBodyLimit` needs to be disabled (or increased).

## Checklist

- [x] I have run `cargo fmt -- --check`
- [x] I have run `cargo clippy --all-targets -- -D warnings`
- [x] I have run `cargo test --release -- --nocapture`
- [x] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [x] I have updated tests where relevant
