### PR TITLE
Remove pull_request trigger from workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Removed pull_request trigger from release drafter workflow.

## Summary

Describe what this pull request changes and why.

## Checklist

- [ ] I have run `cargo fmt -- --check`
- [ ] I have run `cargo clippy --all-targets -- -D warnings`
- [ ] I have run `cargo test --release -- --nocapture`
- [ ] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [ ] I have updated tests where relevant
