### PR TITLE
chore: Add --release to clippy to share build artifacts with tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
       - name: Run Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --release --all-targets -- -D warnings
       - name: Run tests
         run: cargo test --release -- --nocapture
       - name: Run Benchmark performance test

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
       - name: Run Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --release --all-targets -- -D warnings
       - name: Run tests
         run: cargo test --release -- --nocapture
       - name: Run Benchmark performance test


### PR DESCRIPTION
## Summary

Describe what this pull request changes and why.

## Checklist

- [ ] I have run `cargo fmt -- --check`
- [ ] I have run `cargo clippy --all-targets -- -D warnings`
- [ ] I have run `cargo test --release -- --nocapture`
- [ ] I have run `cargo build --release`
- [ ] If performance may be affected, I have run `cargo bench --bench performance`
- [ ] I have updated tests where relevant
