### PR TITLE
feat: configurable image limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,6 +2711,7 @@ dependencies = [
  "comemo",
  "criterion",
  "http-body-util",
+ "image",
  "ironpress",
  "metrics",
  "metrics-exporter-prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ name = "criterion_bench"
 path = "benches/criterion_bench.rs"
 harness = false
 
+[[bench]]
+name = "image_load"
+path = "benches/image_load.rs"
+harness = false
+
 [dependencies]
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "sync", "net", "signal"] }
 axum = "0.8.9"
@@ -57,6 +62,7 @@ http-body-util = "0.1.3"
 reqwest = { version = "0.13.4", features = ["json"] }
 criterion = { version = "0.8.2", features = ["html_reports"] }
 tempfile = "3.27.0"
+image = { version = "0.25.10", default-features = false, features = ["png", "jpeg"] }
 
 [lints.rust]
 unsafe_op_in_unsafe_fn = "warn"

--- a/README.md
+++ b/README.md
@@ -303,6 +303,55 @@ All configuration is done through environment variables. If an environment varia
 | `MAX_CONCURRENT_COMPILATIONS` | Maximum number of concurrent compilation tasks allowed. `0` disables the limit.                                                                          | `4`               |
 | `SEMAPHORE_ACQUIRE_TIMEOUT_SECONDS` | Maximum time in seconds to wait for a compilation semaphore permit. Exceeded timeout returns `503 Service Unavailable`.                              | `10`              |
 | `COMEMO_EVICTION_THRESHOLD`         | Maximum number of cache entries to evict from the comemo memoization cache after each compilation. Higher values free more memory at the cost of cache hit rate. Set to `0` to evict the entire cache. | `15`              |
+| `MAX_IMAGE_DIMENSION_PIXELS`        | Maximum accepted width or height of an uploaded image, in pixels.                                                                                    | `8192`            |
+| `MAX_IMAGE_PIXELS`                  | Maximum accepted total pixel count (width × height) of an uploaded image. This is the primary memory guard for the image endpoint.                    | `25000000` (25 MP) |
+
+#### Sizing the image limits
+
+`MAX_IMAGE_PIXELS` — not `REQUEST_BODY_LIMIT_BYTES` — is what protects the service
+from running out of memory, because peak memory depends on the format:
+
+| Format | How it is embedded | Peak memory |
+| ------ | ------------------ | ----------- |
+| JPEG   | Passed through to the PDF as `DCTDecode` without ever being decoded to pixels | Proportional to the **file size** |
+| PNG, WebP | Decoded to RGBA (4 bytes per pixel), then deflated | Proportional to the **pixel count** |
+
+A body size limit is therefore not a memory guard on its own. A well-compressed
+synthetic PNG (screenshot, map, line drawing) can reach a very high pixel count in
+a small file — for example, a 15 MB PNG of flat colours can exceed 100 megapixels,
+which allocates a ~400 MB RGBA buffer.
+
+Raising these limits requires matching changes elsewhere:
+
+- **Pod memory.** Budget roughly `MAX_IMAGE_PIXELS × 4 bytes` per in-flight
+  compilation, plus the deflate output.
+- **`MAX_CONCURRENT_COMPILATIONS`.** Peak memory is approximately
+  `MAX_CONCURRENT_COMPILATIONS × peak memory per request`. Lower it when raising
+  the image limits, or scale out with more replicas instead.
+- **`COMPILE_TIMEOUT_SECONDS`.** Note that this does **not** free resources: a
+  compilation running on a blocking thread cannot be cancelled once it has
+  started. The client receives `408`, but the work — and its memory — continues
+  until it finishes. The `template_compilations_in_flight_after_timeout` gauge
+  tracks this. Set the timeout high enough that large images actually complete.
+
+Example for images up to 50 MB, matched to a pod with `memory` limits of `3Gi`:
+
+```yaml
+env:
+  - name: REQUEST_BODY_LIMIT_BYTES
+    value: "52428800"
+  - name: MAX_IMAGE_DIMENSION_PIXELS
+    value: "16384"
+  - name: MAX_IMAGE_PIXELS
+    value: "100000000"
+  - name: MAX_CONCURRENT_COMPILATIONS
+    value: "2"
+  - name: COMPILE_TIMEOUT_SECONDS
+    value: "60"
+```
+
+Note that `REQUEST_BODY_LIMIT_BYTES` applies to **all** endpoints, so raising it
+also allows larger JSON and HTML payloads.
 
 ### Logging and tracing
 

--- a/benches/criterion_bench.rs
+++ b/benches/criterion_bench.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use criterion::{Criterion, criterion_group, criterion_main};
 use pdfgenrs::html::typst_to_html;
 use pdfgenrs::pdf::{
-    CompileRequest, ImageLimits, build_html_converter, html_to_pdf, image_to_pdf, typst_to_pdf,
+    CompileRequest, build_html_converter, html_to_pdf, image_to_pdf, typst_to_pdf,
 };
 use pdfgenrs::typst_world;
 use typst::Library;
@@ -132,7 +132,6 @@ fn bench_image_to_pdf(c: &mut Criterion) {
                 &resources_dir(),
                 Arc::clone(&library),
                 pdfgenrs::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-                ImageLimits::default(),
             );
         });
     });
@@ -260,7 +259,6 @@ fn bench_image_to_pdf_jpeg(c: &mut Criterion) {
                 &resources_dir(),
                 Arc::clone(&library),
                 pdfgenrs::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-                ImageLimits::default(),
             );
         });
     });
@@ -287,7 +285,6 @@ fn bench_image_to_pdf_svg(c: &mut Criterion) {
                 &resources_dir(),
                 Arc::clone(&library),
                 pdfgenrs::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-                ImageLimits::default(),
             );
         });
     });

--- a/benches/criterion_bench.rs
+++ b/benches/criterion_bench.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use criterion::{Criterion, criterion_group, criterion_main};
 use pdfgenrs::html::typst_to_html;
 use pdfgenrs::pdf::{
-    CompileRequest, build_html_converter, html_to_pdf, image_to_pdf, typst_to_pdf,
+    CompileRequest, ImageLimits, build_html_converter, html_to_pdf, image_to_pdf, typst_to_pdf,
 };
 use pdfgenrs::typst_world;
 use typst::Library;
@@ -132,6 +132,7 @@ fn bench_image_to_pdf(c: &mut Criterion) {
                 &resources_dir(),
                 Arc::clone(&library),
                 pdfgenrs::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+                ImageLimits::default(),
             );
         });
     });
@@ -259,6 +260,7 @@ fn bench_image_to_pdf_jpeg(c: &mut Criterion) {
                 &resources_dir(),
                 Arc::clone(&library),
                 pdfgenrs::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+                ImageLimits::default(),
             );
         });
     });
@@ -285,6 +287,7 @@ fn bench_image_to_pdf_svg(c: &mut Criterion) {
                 &resources_dir(),
                 Arc::clone(&library),
                 pdfgenrs::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+                ImageLimits::default(),
             );
         });
     });

--- a/benches/image_load.rs
+++ b/benches/image_load.rs
@@ -40,9 +40,9 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use image::ExtendedColorType;
+use image::ImageEncoder;
 use image::codecs::jpeg::JpegEncoder;
 use image::codecs::png::{CompressionType, FilterType, PngEncoder};
-use image::ImageEncoder;
 use pdfgenrs::{build_html_converter, build_router, config, metrics, state, typst_world};
 use reqwest::header;
 use tokio::sync::{RwLock, Semaphore};
@@ -161,7 +161,13 @@ fn ensure_fixtures() -> anyhow::Result<Vec<Fixture>> {
 
     // Photo-like PNG at 32 MP. Compresses poorly, so this is the case where the
     // body limit binds before the pixel limit does.
-    fixtures.push(write_png(&dir, "png-32mp-photo", 8_000, 4_000, Content::Photo)?);
+    fixtures.push(write_png(
+        &dir,
+        "png-32mp-photo",
+        8_000,
+        4_000,
+        Content::Photo,
+    )?);
 
     Ok(fixtures)
 }
@@ -407,7 +413,10 @@ fn percentile(sorted: &[u128], p: usize) -> u128 {
     sorted[idx]
 }
 
-fn spawn_rss_sampler(peak: Arc<AtomicU64>, sampling: Arc<AtomicBool>) -> tokio::task::JoinHandle<()> {
+fn spawn_rss_sampler(
+    peak: Arc<AtomicU64>,
+    sampling: Arc<AtomicBool>,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         while sampling.load(Ordering::Relaxed) {
             if let Some(current) = rss_kb() {
@@ -451,7 +460,9 @@ fn print_report(fixtures: &[Fixture], measurements: &[Measurement]) {
     }
 
     println!("\n## Load results ({REQUESTS_PER_COMBINATION} requests per row)\n");
-    println!("| fixture | concurrency | ok | rejected | total ms | p50 ms | p95 ms | max ms | peak RSS growth |");
+    println!(
+        "| fixture | concurrency | ok | rejected | total ms | p50 ms | p95 ms | max ms | peak RSS growth |"
+    );
     println!("| --- | --- | --- | --- | --- | --- | --- | --- | --- |");
     for m in measurements {
         let rss = match m.peak_rss_growth_kb {

--- a/benches/image_load.rs
+++ b/benches/image_load.rs
@@ -47,6 +47,7 @@ use pdfgenrs::{build_html_converter, build_router, config, metrics, state, typst
 use reqwest::header;
 use tokio::sync::{RwLock, Semaphore};
 use tokio::task::JoinSet;
+use tracing::{info, warn};
 use typst::{Feature, Features};
 
 /// Env var that must be set for the benchmark to do any work.
@@ -93,8 +94,8 @@ fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     if std::env::var(ENABLE_ENV).is_err() {
-        println!(
-            "image_load benchmark skipped. Set {ENABLE_ENV}=1 to run it.\n\
+        info!(
+            "image_load benchmark skipped. Set {ENABLE_ENV}=1 to run it. \
              It generates ~500 MB of fixtures and drives large concurrent compilations."
         );
         return Ok(());
@@ -109,11 +110,11 @@ fn main() -> anyhow::Result<()> {
     let mut measurements = Vec::new();
     for fixture in &fixtures {
         if fixture.file_len > BODY_LIMIT_BYTES as u64 {
-            println!(
-                "SKIP {}: {:.1} MiB exceeds the {} MiB body limit",
-                fixture.name,
-                fixture.file_len as f64 / (1024.0 * 1024.0),
-                BODY_LIMIT_BYTES / (1024 * 1024)
+            warn!(
+                fixture = fixture.name,
+                file_len_mib = fixture.file_len as f64 / (1024.0 * 1024.0),
+                body_limit_mib = BODY_LIMIT_BYTES / (1024 * 1024),
+                "Skipping fixture: exceeds the configured body limit"
             );
             continue;
         }
@@ -122,7 +123,9 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    print_report(&fixtures, &measurements);
+    let report = build_report(&fixtures, &measurements);
+    info!("\n{report}");
+    write_github_summary(&report);
     Ok(())
 }
 
@@ -136,40 +139,17 @@ fn ensure_fixtures() -> anyhow::Result<Vec<Fixture>> {
         .join("image-load-fixtures");
     std::fs::create_dir_all(&dir)?;
 
-    let mut fixtures = Vec::new();
-
-    // The reported failing image: 13583x5417 = 73.6 MP as JPEG. Exercises the
-    // DCTDecode passthrough path, where memory tracks file size, not pixel count.
-    fixtures.push(write_jpeg(
-        &dir,
-        "jpeg-73mp-q85",
-        13_583,
-        5_417,
-        85,
-        Content::Photo,
-    )?);
-
-    // Same dimensions as flat-colour PNG: a small file that still forces a ~294 MB
-    // RGBA decode buffer. This is the worst case a body size limit cannot catch.
-    fixtures.push(write_png(
-        &dir,
-        "png-73mp-flat",
-        13_583,
-        5_417,
-        Content::Flat,
-    )?);
-
-    // Photo-like PNG at 32 MP. Compresses poorly, so this is the case where the
-    // body limit binds before the pixel limit does.
-    fixtures.push(write_png(
-        &dir,
-        "png-32mp-photo",
-        8_000,
-        4_000,
-        Content::Photo,
-    )?);
-
-    Ok(fixtures)
+    Ok(vec![
+        // The reported failing image: 13583x5417 = 73.6 MP as JPEG. Exercises the
+        // DCTDecode passthrough path, where memory tracks file size, not pixel count.
+        write_jpeg(&dir, "jpeg-73mp-q85", 13_583, 5_417, 85, Content::Photo)?,
+        // Same dimensions as flat-colour PNG: a small file that still forces a ~294 MB
+        // RGBA decode buffer. This is the worst case a body size limit cannot catch.
+        write_png(&dir, "png-73mp-flat", 13_583, 5_417, Content::Flat)?,
+        // Photo-like PNG at 32 MP. Compresses poorly, so this is the case where the
+        // body limit binds before the pixel limit does.
+        write_png(&dir, "png-32mp-photo", 8_000, 4_000, Content::Photo)?,
+    ])
 }
 
 #[derive(Clone, Copy)]
@@ -230,7 +210,7 @@ fn write_jpeg(
 ) -> anyhow::Result<Fixture> {
     let path = dir.join(format!("{name}.jpg"));
     if !path.exists() {
-        println!("generating fixture {name} ({width}x{height})...");
+        info!(fixture = name, width, height, "Generating fixture");
         let buf = rgb_buffer(width, height, content);
         let mut file = std::io::BufWriter::new(std::fs::File::create(&path)?);
         JpegEncoder::new_with_quality(&mut file, quality).write_image(
@@ -260,7 +240,7 @@ fn write_png(
 ) -> anyhow::Result<Fixture> {
     let path = dir.join(format!("{name}.png"));
     if !path.exists() {
-        println!("generating fixture {name} ({width}x{height})...");
+        info!(fixture = name, width, height, "Generating fixture");
         let buf = rgb_buffer(width, height, content);
         let mut file = std::io::BufWriter::new(std::fs::File::create(&path)?);
         // Fast compression keeps fixture generation from dominating the run time.
@@ -378,7 +358,7 @@ async fn measure(fixture: &Fixture, concurrency: usize) -> anyhow::Result<Measur
             ok += 1;
         } else {
             rejected += 1;
-            println!("  request returned {status}");
+            warn!(%status, "Request did not return a PDF");
         }
         durations.push(elapsed_ms);
     }
@@ -442,13 +422,19 @@ fn rss_kb() -> Option<u64> {
     None
 }
 
-fn print_report(fixtures: &[Fixture], measurements: &[Measurement]) {
-    println!("\n## Fixtures\n");
-    println!("| fixture | dimensions | megapixels | file size | RGBA buffer if decoded |");
-    println!("| --- | --- | --- | --- | --- |");
+/// Renders the results as Markdown so the same text works in a terminal and in a
+/// GitHub step summary.
+fn build_report(fixtures: &[Fixture], measurements: &[Measurement]) -> String {
+    use std::fmt::Write;
+
+    let mut md = String::new();
+    md.push_str("## Fixtures\n\n");
+    md.push_str("| fixture | dimensions | megapixels | file size | RGBA buffer if decoded |\n");
+    md.push_str("| --- | --- | --- | --- | --- |\n");
     for f in fixtures {
         let px = u64::from(f.width) * u64::from(f.height);
-        println!(
+        let _ = writeln!(
+            md,
             "| {} | {}x{} | {:.1} MP | {:.1} MiB | {:.0} MiB |",
             f.name,
             f.width,
@@ -459,17 +445,21 @@ fn print_report(fixtures: &[Fixture], measurements: &[Measurement]) {
         );
     }
 
-    println!("\n## Load results ({REQUESTS_PER_COMBINATION} requests per row)\n");
-    println!(
-        "| fixture | concurrency | ok | rejected | total ms | p50 ms | p95 ms | max ms | peak RSS growth |"
+    let _ = write!(
+        md,
+        "\n## Load results ({REQUESTS_PER_COMBINATION} requests per row)\n\n"
     );
-    println!("| --- | --- | --- | --- | --- | --- | --- | --- | --- |");
+    md.push_str(
+        "| fixture | concurrency | ok | rejected | total ms | p50 ms | p95 ms | max ms | peak RSS growth |\n",
+    );
+    md.push_str("| --- | --- | --- | --- | --- | --- | --- | --- | --- |\n");
     for m in measurements {
         let rss = match m.peak_rss_growth_kb {
             Some(kb) => format!("{:.0} MiB", kb as f64 / 1024.0),
             None => "n/a (not Linux)".to_string(),
         };
-        println!(
+        let _ = writeln!(
+            md,
             "| {} | {} | {} | {} | {} | {} | {} | {} | {} |",
             m.fixture,
             m.concurrency,
@@ -484,22 +474,41 @@ fn print_report(fixtures: &[Fixture], measurements: &[Measurement]) {
     }
 
     if rss_kb().is_none() {
-        println!(
-            "\nNote: peak RSS is only sampled on Linux. Run under \
-             `docker run -m 3g` to measure memory and find the OOM threshold."
+        md.push_str(
+            "\n> Peak RSS is only sampled on Linux. Run under `docker run -m 3g` to measure \
+             memory and find the OOM threshold.\n",
         );
     }
 
-    println!(
-        "\nNote: the semaphore gates compilation, not body buffering. Axum buffers each \
-         request body in full before the handler runs, so {REQUESTS_PER_COMBINATION} concurrent \
-         uploads hold {REQUESTS_PER_COMBINATION} bodies in memory regardless of \
-         MAX_CONCURRENT_COMPILATIONS. Budget for that separately from the RGBA decode buffers."
+    let _ = write!(
+        md,
+        "\n> The semaphore gates compilation, not body buffering. Axum buffers each request \
+         body in full before the handler runs, so {REQUESTS_PER_COMBINATION} concurrent uploads \
+         hold {REQUESTS_PER_COMBINATION} bodies in memory regardless of \
+         MAX_CONCURRENT_COMPILATIONS. Budget for that separately from the RGBA decode buffers.\n"
     );
 
-    println!(
-        "\nNote: fixture generation itself allocates a full RGB buffer (~220 MiB for the \
-         73 MP fixtures) and is included in the process RSS if it ran in this invocation. \
-         Re-run to measure against cached fixtures."
+    md.push_str(
+        "\n> Fixture generation itself allocates a full RGB buffer (~220 MiB for the 73 MP \
+         fixtures) and is included in the process RSS if it ran in this invocation. Re-run to \
+         measure against cached fixtures.\n",
     );
+
+    md
+}
+
+/// Writes the report to the GitHub step summary when running in Actions.
+///
+/// Mirrors `write_github_summary` in `benches/performance.rs`.
+fn write_github_summary(report: &str) {
+    let Ok(summary_file) = std::env::var("GITHUB_STEP_SUMMARY") else {
+        return;
+    };
+    if let Err(e) = std::fs::write(&summary_file, report) {
+        warn!(
+            path = %summary_file,
+            error = %e,
+            "Failed to write GitHub step summary"
+        );
+    }
 }

--- a/benches/image_load.rs
+++ b/benches/image_load.rs
@@ -1,0 +1,494 @@
+//! Load test for the image-to-PDF endpoint with large images.
+//!
+//! This is deliberately *not* part of `benches/performance.rs`. That benchmark is a
+//! fast CI regression guard with fixed millisecond thresholds; this one allocates
+//! hundreds of megabytes and is meant to be run deliberately when tuning
+//! `MAX_IMAGE_PIXELS`, `MAX_CONCURRENT_COMPILATIONS` and pod memory limits.
+//!
+//! Run with:
+//!
+//! ```text
+//! IMAGE_LOAD_BENCH=1 cargo bench --bench image_load
+//! ```
+//!
+//! To find the actual OOM threshold rather than estimating it, run the benchmark
+//! under a memory-limited container. Build and run must be separate steps: the
+//! memory limit is meant for the benchmark, and compiling `typst-library` at
+//! `opt-level=3` needs several gigabytes on its own, so building under `-m 3g`
+//! gets the compiler OOM-killed before the benchmark ever starts.
+//!
+//! ```text
+//! # 1. Build with full memory available. A separate target dir avoids thrashing
+//! #    the host's macOS/Windows artifacts in the same directory.
+//! docker run --rm -v "$PWD:/src" -w /src -e CARGO_TARGET_DIR=/src/target/linux \
+//!   rust:latest cargo bench --bench image_load --no-run
+//!
+//! # 2. Run only the benchmark binary under the memory limit.
+//! docker run --rm -m 3g -v "$PWD:/src" -w /src rust:latest \
+//!   bash -c 'IMAGE_LOAD_BENCH=1 exec $(find target/linux/release/deps -type f -name "image_load-*" ! -name "*.d")'
+//! ```
+//!
+//! Peak RSS is only measured on Linux, since it is read from `/proc/self/status`.
+//! Numbers from macOS are latency-only and do not reflect behaviour under cgroup
+//! memory limits.
+
+use std::collections::HashMap;
+use std::future::IntoFuture;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use image::ExtendedColorType;
+use image::codecs::jpeg::JpegEncoder;
+use image::codecs::png::{CompressionType, FilterType, PngEncoder};
+use image::ImageEncoder;
+use pdfgenrs::{build_html_converter, build_router, config, metrics, state, typst_world};
+use reqwest::header;
+use tokio::sync::{RwLock, Semaphore};
+use tokio::task::JoinSet;
+use typst::{Feature, Features};
+
+/// Env var that must be set for the benchmark to do any work.
+///
+/// Without this gate, a plain `cargo bench` would allocate hundreds of megabytes
+/// of fixture data in CI.
+const ENABLE_ENV: &str = "IMAGE_LOAD_BENCH";
+
+/// Requests fired per (fixture, concurrency) combination.
+const REQUESTS_PER_COMBINATION: usize = 12;
+
+/// Concurrency settings to compare. This is the matrix that answers
+/// "does lowering MAX_CONCURRENT_COMPILATIONS actually cost throughput?".
+const CONCURRENCY_MATRIX: [usize; 3] = [1, 2, 4];
+
+/// Body limit used for the benchmark, matching the 50 MB target.
+const BODY_LIMIT_BYTES: usize = 50 * 1024 * 1024;
+const MAX_IMAGE_DIMENSION_PIXELS: u32 = 16_384;
+const MAX_IMAGE_PIXELS: u64 = 100_000_000;
+const COMPILE_TIMEOUT_SECONDS: u64 = 60;
+
+struct Fixture {
+    name: &'static str,
+    content_type: &'static str,
+    path: PathBuf,
+    width: u32,
+    height: u32,
+    file_len: u64,
+}
+
+struct Measurement {
+    fixture: &'static str,
+    concurrency: usize,
+    ok: usize,
+    rejected: usize,
+    total_ms: u128,
+    p50_ms: u128,
+    p95_ms: u128,
+    max_ms: u128,
+    peak_rss_growth_kb: Option<u64>,
+}
+
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    if std::env::var(ENABLE_ENV).is_err() {
+        println!(
+            "image_load benchmark skipped. Set {ENABLE_ENV}=1 to run it.\n\
+             It generates ~500 MB of fixtures and drives large concurrent compilations."
+        );
+        return Ok(());
+    }
+
+    let fixtures = ensure_fixtures()?;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    let mut measurements = Vec::new();
+    for fixture in &fixtures {
+        if fixture.file_len > BODY_LIMIT_BYTES as u64 {
+            println!(
+                "SKIP {}: {:.1} MiB exceeds the {} MiB body limit",
+                fixture.name,
+                fixture.file_len as f64 / (1024.0 * 1024.0),
+                BODY_LIMIT_BYTES / (1024 * 1024)
+            );
+            continue;
+        }
+        for concurrency in CONCURRENCY_MATRIX {
+            measurements.push(runtime.block_on(measure(fixture, concurrency))?);
+        }
+    }
+
+    print_report(&fixtures, &measurements);
+    Ok(())
+}
+
+/// Generates the fixture images once and caches them under `target/`.
+///
+/// Fixtures are generated rather than committed: a 25-50 MB binary would stay in
+/// the git history permanently. `target/` is already gitignored.
+fn ensure_fixtures() -> anyhow::Result<Vec<Fixture>> {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("image-load-fixtures");
+    std::fs::create_dir_all(&dir)?;
+
+    let mut fixtures = Vec::new();
+
+    // The reported failing image: 13583x5417 = 73.6 MP as JPEG. Exercises the
+    // DCTDecode passthrough path, where memory tracks file size, not pixel count.
+    fixtures.push(write_jpeg(
+        &dir,
+        "jpeg-73mp-q85",
+        13_583,
+        5_417,
+        85,
+        Content::Photo,
+    )?);
+
+    // Same dimensions as flat-colour PNG: a small file that still forces a ~294 MB
+    // RGBA decode buffer. This is the worst case a body size limit cannot catch.
+    fixtures.push(write_png(
+        &dir,
+        "png-73mp-flat",
+        13_583,
+        5_417,
+        Content::Flat,
+    )?);
+
+    // Photo-like PNG at 32 MP. Compresses poorly, so this is the case where the
+    // body limit binds before the pixel limit does.
+    fixtures.push(write_png(&dir, "png-32mp-photo", 8_000, 4_000, Content::Photo)?);
+
+    Ok(fixtures)
+}
+
+#[derive(Clone, Copy)]
+enum Content {
+    /// Large uniform areas with a few bands. Compresses extremely well.
+    Flat,
+    /// Smooth gradients plus deterministic noise, approximating photographic data.
+    Photo,
+}
+
+/// Fills an RGB8 buffer.
+///
+/// Uses a deterministic LCG rather than a random number generator so that repeated
+/// runs produce byte-identical fixtures and therefore comparable file sizes.
+fn rgb_buffer(width: u32, height: u32, content: Content) -> Vec<u8> {
+    let pixels = width as usize * height as usize;
+    let mut buf = vec![0u8; pixels * 3];
+    let mut seed: u32 = 0x1234_5678;
+
+    for y in 0..height as usize {
+        for x in 0..width as usize {
+            let i = (y * width as usize + x) * 3;
+            match content {
+                Content::Flat => {
+                    let band = (y / 512) % 4;
+                    let (r, g, b) = match band {
+                        0 => (250, 250, 250),
+                        1 => (200, 40, 40),
+                        2 => (250, 250, 250),
+                        _ => (20, 20, 60),
+                    };
+                    buf[i] = r;
+                    buf[i + 1] = g;
+                    buf[i + 2] = b;
+                }
+                Content::Photo => {
+                    seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                    let noise = (seed >> 24) as u8 / 8;
+                    let gx = ((x * 255) / width as usize) as u8;
+                    let gy = ((y * 255) / height as usize) as u8;
+                    buf[i] = gx.wrapping_add(noise);
+                    buf[i + 1] = gy.wrapping_add(noise);
+                    buf[i + 2] = gx.wrapping_add(gy).wrapping_add(noise);
+                }
+            }
+        }
+    }
+    buf
+}
+
+fn write_jpeg(
+    dir: &Path,
+    name: &'static str,
+    width: u32,
+    height: u32,
+    quality: u8,
+    content: Content,
+) -> anyhow::Result<Fixture> {
+    let path = dir.join(format!("{name}.jpg"));
+    if !path.exists() {
+        println!("generating fixture {name} ({width}x{height})...");
+        let buf = rgb_buffer(width, height, content);
+        let mut file = std::io::BufWriter::new(std::fs::File::create(&path)?);
+        JpegEncoder::new_with_quality(&mut file, quality).write_image(
+            &buf,
+            width,
+            height,
+            ExtendedColorType::Rgb8,
+        )?;
+    }
+    let file_len = std::fs::metadata(&path)?.len();
+    Ok(Fixture {
+        name,
+        content_type: "image/jpeg",
+        path,
+        width,
+        height,
+        file_len,
+    })
+}
+
+fn write_png(
+    dir: &Path,
+    name: &'static str,
+    width: u32,
+    height: u32,
+    content: Content,
+) -> anyhow::Result<Fixture> {
+    let path = dir.join(format!("{name}.png"));
+    if !path.exists() {
+        println!("generating fixture {name} ({width}x{height})...");
+        let buf = rgb_buffer(width, height, content);
+        let mut file = std::io::BufWriter::new(std::fs::File::create(&path)?);
+        // Fast compression keeps fixture generation from dominating the run time.
+        // Flat content still compresses to a tiny file, which is the point.
+        PngEncoder::new_with_quality(&mut file, CompressionType::Fast, FilterType::Adaptive)
+            .write_image(&buf, width, height, ExtendedColorType::Rgb8)?;
+    }
+    let file_len = std::fs::metadata(&path)?.len();
+    Ok(Fixture {
+        name,
+        content_type: "image/png",
+        path,
+        width,
+        height,
+        file_len,
+    })
+}
+
+fn bench_state(concurrency: usize) -> anyhow::Result<state::AppState> {
+    let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let cfg = config::Config {
+        port: 0,
+        root_dir: root_dir.clone(),
+        templates_dir: root_dir.join("templates"),
+        resources_dir: root_dir.join("resources"),
+        data_dir: root_dir.join("data"),
+        fonts_dir: root_dir.join("fonts"),
+        dev_mode: false,
+        request_body_limit_bytes: BODY_LIMIT_BYTES,
+        compile_timeout_seconds: COMPILE_TIMEOUT_SECONDS,
+        shutdown_drain_seconds: 0,
+        max_concurrent_compilations: concurrency,
+        semaphore_acquire_timeout_seconds: 10,
+        comemo_eviction_threshold: config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+        max_image_dimension_pixels: MAX_IMAGE_DIMENSION_PIXELS,
+        max_image_pixels: MAX_IMAGE_PIXELS,
+    };
+
+    let fonts = Arc::new(typst_world::load_fonts(&cfg.font_dir())?);
+
+    Ok(state::AppState {
+        templates: Arc::new(HashMap::new()),
+        data: Arc::new(RwLock::new(HashMap::new())),
+        aliveness: state::AppAliveness::new(),
+        fonts,
+        pdf_library: Arc::new(typst_world::build_library(Features::default())),
+        html_library: Arc::new(typst_world::build_library(
+            [Feature::Html].into_iter().collect(),
+        )),
+        html_converter: Arc::new(build_html_converter(&cfg.font_dir(), &cfg.root_dir).0),
+        root_dir: Arc::new(cfg.root_dir.clone()),
+        resources_dir: Arc::new(cfg.resource_root()),
+        // The existing performance benchmark sets this to None, which disables the
+        // semaphore entirely and makes MAX_CONCURRENT_COMPILATIONS untestable.
+        compile_semaphore: Some(Arc::new(Semaphore::new(concurrency))),
+        config: cfg,
+    })
+}
+
+async fn measure(fixture: &Fixture, concurrency: usize) -> anyhow::Result<Measurement> {
+    let app_state = bench_state(concurrency)?;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    let url = format!("http://127.0.0.1:{port}/api/v1/genpdf/image/bench");
+
+    let server = tokio::spawn(
+        axum::serve(
+            listener,
+            build_router(app_state, metrics::test_metrics_handle()),
+        )
+        .into_future(),
+    );
+
+    let image_bytes = axum::body::Bytes::from(std::fs::read(&fixture.path)?);
+    let client = Arc::new(
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(300))
+            .build()?,
+    );
+
+    let baseline_rss = rss_kb();
+    let peak_rss = Arc::new(AtomicU64::new(0));
+    let sampling = Arc::new(AtomicBool::new(true));
+    let sampler = spawn_rss_sampler(Arc::clone(&peak_rss), Arc::clone(&sampling));
+
+    let start = Instant::now();
+    let mut join_set = JoinSet::new();
+    for _ in 0..REQUESTS_PER_COMBINATION {
+        let client = Arc::clone(&client);
+        let url = url.clone();
+        // Cloning `Bytes` is a refcount bump, so the client side does not add a
+        // copy of the body per request and pollute the RSS measurement.
+        let body = image_bytes.clone();
+        let content_type = fixture.content_type;
+        join_set.spawn(async move {
+            let request_start = Instant::now();
+            let response = client
+                .post(&url)
+                .header(header::CONTENT_TYPE, content_type)
+                .body(body)
+                .send()
+                .await?;
+            let status = response.status();
+            let bytes = response.bytes().await?;
+            anyhow::Ok((status, bytes.len(), request_start.elapsed().as_millis()))
+        });
+    }
+
+    let mut durations = Vec::with_capacity(REQUESTS_PER_COMBINATION);
+    let mut ok = 0;
+    let mut rejected = 0;
+    while let Some(joined) = join_set.join_next().await {
+        let (status, len, elapsed_ms) = joined??;
+        if status.is_success() && len > 0 {
+            ok += 1;
+        } else {
+            rejected += 1;
+            println!("  request returned {status}");
+        }
+        durations.push(elapsed_ms);
+    }
+    let total_ms = start.elapsed().as_millis();
+
+    sampling.store(false, Ordering::Relaxed);
+    sampler.await?;
+    server.abort();
+
+    durations.sort_unstable();
+    let peak = peak_rss.load(Ordering::Relaxed);
+    let peak_rss_growth_kb = baseline_rss.map(|base| peak.saturating_sub(base));
+
+    Ok(Measurement {
+        fixture: fixture.name,
+        concurrency,
+        ok,
+        rejected,
+        total_ms,
+        p50_ms: percentile(&durations, 50),
+        p95_ms: percentile(&durations, 95),
+        max_ms: durations.last().copied().unwrap_or(0),
+        peak_rss_growth_kb,
+    })
+}
+
+fn percentile(sorted: &[u128], p: usize) -> u128 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = (sorted.len() * p / 100).min(sorted.len() - 1);
+    sorted[idx]
+}
+
+fn spawn_rss_sampler(peak: Arc<AtomicU64>, sampling: Arc<AtomicBool>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while sampling.load(Ordering::Relaxed) {
+            if let Some(current) = rss_kb() {
+                peak.fetch_max(current, Ordering::Relaxed);
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn rss_kb() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    status
+        .lines()
+        .find(|line| line.starts_with("VmRSS:"))
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|value| value.parse().ok())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn rss_kb() -> Option<u64> {
+    None
+}
+
+fn print_report(fixtures: &[Fixture], measurements: &[Measurement]) {
+    println!("\n## Fixtures\n");
+    println!("| fixture | dimensions | megapixels | file size | RGBA buffer if decoded |");
+    println!("| --- | --- | --- | --- | --- |");
+    for f in fixtures {
+        let px = u64::from(f.width) * u64::from(f.height);
+        println!(
+            "| {} | {}x{} | {:.1} MP | {:.1} MiB | {:.0} MiB |",
+            f.name,
+            f.width,
+            f.height,
+            px as f64 / 1e6,
+            f.file_len as f64 / (1024.0 * 1024.0),
+            (px * 4) as f64 / (1024.0 * 1024.0)
+        );
+    }
+
+    println!("\n## Load results ({REQUESTS_PER_COMBINATION} requests per row)\n");
+    println!("| fixture | concurrency | ok | rejected | total ms | p50 ms | p95 ms | max ms | peak RSS growth |");
+    println!("| --- | --- | --- | --- | --- | --- | --- | --- | --- |");
+    for m in measurements {
+        let rss = match m.peak_rss_growth_kb {
+            Some(kb) => format!("{:.0} MiB", kb as f64 / 1024.0),
+            None => "n/a (not Linux)".to_string(),
+        };
+        println!(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+            m.fixture,
+            m.concurrency,
+            m.ok,
+            m.rejected,
+            m.total_ms,
+            m.p50_ms,
+            m.p95_ms,
+            m.max_ms,
+            rss
+        );
+    }
+
+    if rss_kb().is_none() {
+        println!(
+            "\nNote: peak RSS is only sampled on Linux. Run under \
+             `docker run -m 3g` to measure memory and find the OOM threshold."
+        );
+    }
+
+    println!(
+        "\nNote: the semaphore gates compilation, not body buffering. Axum buffers each \
+         request body in full before the handler runs, so {REQUESTS_PER_COMBINATION} concurrent \
+         uploads hold {REQUESTS_PER_COMBINATION} bodies in memory regardless of \
+         MAX_CONCURRENT_COMPILATIONS. Budget for that separately from the RGBA decode buffers."
+    );
+
+    println!(
+        "\nNote: fixture generation itself allocates a full RGB buffer (~220 MiB for the \
+         73 MP fixtures) and is included in the process RSS if it ran in this invocation. \
+         Re-run to measure against cached fixtures."
+    );
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ const SHUTDOWN_DRAIN_SECONDS_ENV: &str = "SHUTDOWN_DRAIN_SECONDS";
 const MAX_CONCURRENT_COMPILATIONS_ENV: &str = "MAX_CONCURRENT_COMPILATIONS";
 const SEMAPHORE_ACQUIRE_TIMEOUT_SECONDS_ENV: &str = "SEMAPHORE_ACQUIRE_TIMEOUT_SECONDS";
 const COMEMO_EVICTION_THRESHOLD_ENV: &str = "COMEMO_EVICTION_THRESHOLD";
+const MAX_IMAGE_DIMENSION_PIXELS_ENV: &str = "MAX_IMAGE_DIMENSION_PIXELS";
+const MAX_IMAGE_PIXELS_ENV: &str = "MAX_IMAGE_PIXELS";
 
 const DEFAULT_PORT: u16 = 8080;
 const DEFAULT_ROOT_DIR: &str = ".";
@@ -29,6 +31,14 @@ const DEFAULT_SHUTDOWN_DRAIN_SECONDS: u64 = 5;
 const DEFAULT_MAX_CONCURRENT_COMPILATIONS: usize = 4;
 const DEFAULT_SEMAPHORE_ACQUIRE_TIMEOUT_SECONDS: u64 = 10;
 pub const DEFAULT_COMEMO_EVICTION_THRESHOLD: usize = 15;
+/// Maximum allowed width or height of an uploaded image, in pixels.
+pub const DEFAULT_MAX_IMAGE_DIMENSION_PIXELS: u32 = 8_192;
+/// Maximum allowed total pixel count (width × height) of an uploaded image.
+///
+/// This is the primary memory guard for the image endpoint: PNG and WebP are
+/// decoded to RGBA (4 bytes per pixel) before being embedded, so peak memory
+/// scales with the pixel count rather than with the compressed file size.
+pub const DEFAULT_MAX_IMAGE_PIXELS: u64 = 25_000_000;
 
 /// Runtime configuration for the pdfgenrs server.
 ///
@@ -76,6 +86,13 @@ pub struct Config {
     /// each compilation. Higher values free more memory at the cost of cache hit rate.
     /// Set to `0` to evict the entire cache. Defaults to `15` (`COMEMO_EVICTION_THRESHOLD`).
     pub comemo_eviction_threshold: usize,
+    /// Maximum accepted width or height of an uploaded image, in pixels. Defaults to
+    /// `8192` (`MAX_IMAGE_DIMENSION_PIXELS`).
+    pub max_image_dimension_pixels: u32,
+    /// Maximum accepted total pixel count (width × height) of an uploaded image.
+    /// This is the primary memory guard for the image endpoint, since PNG and WebP
+    /// are decoded to RGBA before embedding. Defaults to `25000000` (`MAX_IMAGE_PIXELS`).
+    pub max_image_pixels: u64,
 }
 
 impl Default for Config {
@@ -120,6 +137,16 @@ impl Config {
                 }
             }
         };
+        let parse_u32 = |key: &str| {
+            let raw = env_var(key)?;
+            match raw.parse::<u32>() {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    warn!(env = key, value = %raw, error = %e, "Invalid env value, falling back to default");
+                    None
+                }
+            }
+        };
         let path_or = |key: &str, default: &str| {
             PathBuf::from(env_var(key).unwrap_or_else(|| default.to_owned()))
         };
@@ -129,6 +156,9 @@ impl Config {
                 .unwrap_or(false)
         };
 
+        let request_body_limit_bytes =
+            parse_usize(REQUEST_BODY_LIMIT_BYTES_ENV).unwrap_or(DEFAULT_REQUEST_BODY_LIMIT_BYTES);
+
         Self {
             port: parse_u16(SERVER_PORT_ENV).unwrap_or(DEFAULT_PORT),
             root_dir: path_or(ROOT_DIR_ENV, DEFAULT_ROOT_DIR),
@@ -137,8 +167,7 @@ impl Config {
             data_dir: path_or(DATA_DIR_ENV, DEFAULT_DATA_DIR),
             fonts_dir: path_or(FONTS_DIR_ENV, DEFAULT_FONTS_DIR),
             dev_mode: bool_var(DEV_MODE_ENV),
-            request_body_limit_bytes: parse_usize(REQUEST_BODY_LIMIT_BYTES_ENV)
-                .unwrap_or(DEFAULT_REQUEST_BODY_LIMIT_BYTES),
+            request_body_limit_bytes,
             compile_timeout_seconds: parse_u64(COMPILE_TIMEOUT_SECONDS_ENV)
                 .unwrap_or(DEFAULT_COMPILE_TIMEOUT_SECONDS),
             shutdown_drain_seconds: parse_u64(SHUTDOWN_DRAIN_SECONDS_ENV)
@@ -149,6 +178,9 @@ impl Config {
                 .unwrap_or(DEFAULT_SEMAPHORE_ACQUIRE_TIMEOUT_SECONDS),
             comemo_eviction_threshold: parse_usize(COMEMO_EVICTION_THRESHOLD_ENV)
                 .unwrap_or(DEFAULT_COMEMO_EVICTION_THRESHOLD),
+            max_image_dimension_pixels: parse_u32(MAX_IMAGE_DIMENSION_PIXELS_ENV)
+                .unwrap_or(DEFAULT_MAX_IMAGE_DIMENSION_PIXELS),
+            max_image_pixels: parse_u64(MAX_IMAGE_PIXELS_ENV).unwrap_or(DEFAULT_MAX_IMAGE_PIXELS),
         }
     }
 
@@ -182,6 +214,32 @@ impl Config {
                 env = REQUEST_BODY_LIMIT_BYTES_ENV,
                 value = self.request_body_limit_bytes,
                 "request_body_limit_bytes is 0, all requests with a body will be rejected"
+            );
+        }
+        if self.max_image_dimension_pixels == 0 {
+            warn!(
+                env = MAX_IMAGE_DIMENSION_PIXELS_ENV,
+                value = self.max_image_dimension_pixels,
+                "max_image_dimension_pixels is 0, all images will be rejected"
+            );
+        }
+        if self.max_image_pixels == 0 {
+            warn!(
+                env = MAX_IMAGE_PIXELS_ENV,
+                value = self.max_image_pixels,
+                "max_image_pixels is 0, all images will be rejected"
+            );
+        }
+        // PNG and WebP are decoded to RGBA (4 bytes per pixel) before embedding, so this
+        // is the dominant term in peak memory per in-flight compilation.
+        let estimated_peak_bytes = self.max_image_pixels.saturating_mul(4);
+        if estimated_peak_bytes > 400_000_000 {
+            warn!(
+                env = MAX_IMAGE_PIXELS_ENV,
+                value = self.max_image_pixels,
+                estimated_rgba_bytes = estimated_peak_bytes,
+                max_concurrent_compilations = self.max_concurrent_compilations,
+                "max_image_pixels allows large RGBA decode buffers; verify pod memory limits and MAX_CONCURRENT_COMPILATIONS"
             );
         }
     }
@@ -259,6 +317,11 @@ mod tests {
             config.comemo_eviction_threshold,
             DEFAULT_COMEMO_EVICTION_THRESHOLD
         );
+        assert_eq!(
+            config.max_image_dimension_pixels,
+            DEFAULT_MAX_IMAGE_DIMENSION_PIXELS
+        );
+        assert_eq!(config.max_image_pixels, DEFAULT_MAX_IMAGE_PIXELS);
     }
 
     #[test]
@@ -277,6 +340,8 @@ mod tests {
             (MAX_CONCURRENT_COMPILATIONS_ENV, "4"),
             (SEMAPHORE_ACQUIRE_TIMEOUT_SECONDS_ENV, "15"),
             (COMEMO_EVICTION_THRESHOLD_ENV, "30"),
+            (MAX_IMAGE_DIMENSION_PIXELS_ENV, "16384"),
+            (MAX_IMAGE_PIXELS_ENV, "100000000"),
         ]));
 
         assert_eq!(config.port, 9090);
@@ -292,6 +357,22 @@ mod tests {
         assert_eq!(config.max_concurrent_compilations, 4);
         assert_eq!(config.semaphore_acquire_timeout_seconds, 15);
         assert_eq!(config.comemo_eviction_threshold, 30);
+        assert_eq!(config.max_image_dimension_pixels, 16_384);
+        assert_eq!(config.max_image_pixels, 100_000_000);
+    }
+
+    #[test]
+    fn image_limits_fall_back_to_defaults_for_invalid_env_values() {
+        let config = Config::from_env_fn(env_from(&[
+            (MAX_IMAGE_DIMENSION_PIXELS_ENV, "not-a-number"),
+            (MAX_IMAGE_PIXELS_ENV, "-1"),
+        ]));
+
+        assert_eq!(
+            config.max_image_dimension_pixels,
+            DEFAULT_MAX_IMAGE_DIMENSION_PIXELS
+        );
+        assert_eq!(config.max_image_pixels, DEFAULT_MAX_IMAGE_PIXELS);
     }
 
     #[test]
@@ -407,6 +488,8 @@ mod tests {
             max_concurrent_compilations: DEFAULT_MAX_CONCURRENT_COMPILATIONS,
             semaphore_acquire_timeout_seconds: DEFAULT_SEMAPHORE_ACQUIRE_TIMEOUT_SECONDS,
             comemo_eviction_threshold: DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            max_image_dimension_pixels: DEFAULT_MAX_IMAGE_DIMENSION_PIXELS,
+            max_image_pixels: DEFAULT_MAX_IMAGE_PIXELS,
         };
 
         assert_eq!(config.font_dir(), PathBuf::from("/tmp/root/fonts"));
@@ -428,6 +511,8 @@ mod tests {
             max_concurrent_compilations: DEFAULT_MAX_CONCURRENT_COMPILATIONS,
             semaphore_acquire_timeout_seconds: DEFAULT_SEMAPHORE_ACQUIRE_TIMEOUT_SECONDS,
             comemo_eviction_threshold: DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            max_image_dimension_pixels: DEFAULT_MAX_IMAGE_DIMENSION_PIXELS,
+            max_image_pixels: DEFAULT_MAX_IMAGE_PIXELS,
         };
 
         assert_eq!(config.font_dir(), PathBuf::from("/tmp/shared/fonts"));
@@ -449,6 +534,8 @@ mod tests {
             max_concurrent_compilations: DEFAULT_MAX_CONCURRENT_COMPILATIONS,
             semaphore_acquire_timeout_seconds: DEFAULT_SEMAPHORE_ACQUIRE_TIMEOUT_SECONDS,
             comemo_eviction_threshold: DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            max_image_dimension_pixels: DEFAULT_MAX_IMAGE_DIMENSION_PIXELS,
+            max_image_pixels: DEFAULT_MAX_IMAGE_PIXELS,
         };
 
         assert_eq!(config.resource_root(), PathBuf::from("/tmp/root/resources"));
@@ -470,6 +557,8 @@ mod tests {
             max_concurrent_compilations: DEFAULT_MAX_CONCURRENT_COMPILATIONS,
             semaphore_acquire_timeout_seconds: DEFAULT_SEMAPHORE_ACQUIRE_TIMEOUT_SECONDS,
             comemo_eviction_threshold: DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            max_image_dimension_pixels: DEFAULT_MAX_IMAGE_DIMENSION_PIXELS,
+            max_image_pixels: DEFAULT_MAX_IMAGE_PIXELS,
         };
 
         assert_eq!(

--- a/src/http/routes/pdf.rs
+++ b/src/http/routes/pdf.rs
@@ -136,7 +136,7 @@ pub(crate) async fn post_pdf_from_image(
     };
 
     let pdf_bytes = compile_blocking(&state, app_name.clone(), None, move || {
-        gen_pdf::image_to_pdf(
+        gen_pdf::image_to_pdf_with_limits(
             image_bytes,
             image_path,
             fonts,

--- a/src/http/routes/pdf.rs
+++ b/src/http/routes/pdf.rs
@@ -130,6 +130,10 @@ pub(crate) async fn post_pdf_from_image(
     let resources_dir = Arc::clone(&state.resources_dir);
     let library = Arc::clone(&state.pdf_library);
     let eviction_threshold = state.config.comemo_eviction_threshold;
+    let limits = gen_pdf::ImageLimits {
+        max_dimension_pixels: state.config.max_image_dimension_pixels,
+        max_pixels: state.config.max_image_pixels,
+    };
 
     let pdf_bytes = compile_blocking(&state, app_name.clone(), None, move || {
         gen_pdf::image_to_pdf(
@@ -140,6 +144,7 @@ pub(crate) async fn post_pdf_from_image(
             &resources_dir,
             library,
             eviction_threshold,
+            limits,
         )
     })
     .await?;
@@ -585,6 +590,74 @@ mod tests {
             StatusCode::OK,
             "PNG bytes with Content-Type: image/jpeg should not produce a PDF"
         );
+        Ok(())
+    }
+
+    /// Verifies that `max_image_pixels` is threaded from config all the way into
+    /// `validate_image_dimensions`. Lowering the limit below the test image is the
+    /// only practical way to assert this without a multi-megapixel fixture.
+    #[tokio::test]
+    async fn post_pdf_from_image_rejects_image_above_configured_pixel_limit() -> anyhow::Result<()>
+    {
+        let mut state = make_state(HashMap::new(), HashMap::new(), false)?;
+        state.config.max_image_pixels = 1;
+        let server = TestServer::new(make_router(state, false));
+
+        let response = server
+            .post("/image/myapp")
+            .content_type("image/png")
+            .bytes(Bytes::from(std::fs::read(
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("resources")
+                    .join("NAVLogoRed.png"),
+            )?))
+            .await;
+
+        assert_ne!(
+            response.status_code(),
+            StatusCode::OK,
+            "image above max_image_pixels should be rejected"
+        );
+        Ok(())
+    }
+
+    /// Verifies the opposite direction: an image that the default limits would reject
+    /// is accepted once `max_image_dimension_pixels` is raised.
+    #[tokio::test]
+    async fn post_pdf_from_image_accepts_image_within_raised_dimension_limit() -> anyhow::Result<()>
+    {
+        let mut state = make_state(HashMap::new(), HashMap::new(), false)?;
+        state.config.max_image_dimension_pixels = 1;
+        let server = TestServer::new(make_router(state, false));
+
+        let rejected = server
+            .post("/image/myapp")
+            .content_type("image/png")
+            .bytes(Bytes::from(std::fs::read(
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("resources")
+                    .join("NAVLogoRed.png"),
+            )?))
+            .await;
+        assert_ne!(rejected.status_code(), StatusCode::OK);
+
+        let mut state = make_state(HashMap::new(), HashMap::new(), false)?;
+        state.config.max_image_dimension_pixels = 16_384;
+        state.config.max_image_pixels = 100_000_000;
+        let server = TestServer::new(make_router(state, false));
+
+        let accepted = server
+            .post("/image/myapp")
+            .content_type("image/png")
+            .bytes(Bytes::from(std::fs::read(
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("resources")
+                    .join("NAVLogoRed.png"),
+            )?))
+            .await;
+
+        assert_eq!(accepted.status_code(), StatusCode::OK);
+        assert!(is_pdf(accepted.as_bytes()));
         Ok(())
     }
 

--- a/src/rendering/pdf.rs
+++ b/src/rendering/pdf.rs
@@ -165,8 +165,35 @@ pub fn build_html_converter(fonts_dir: &Path, base_path: &Path) -> (HtmlConverte
     (converter, fonts.len())
 }
 
-const MAX_IMAGE_DIMENSION_PIXELS: u32 = 8_192;
-const MAX_IMAGE_PIXELS: u64 = 25_000_000;
+const MAX_IMAGE_DIMENSION_PIXELS: u32 = crate::config::DEFAULT_MAX_IMAGE_DIMENSION_PIXELS;
+const MAX_IMAGE_PIXELS: u64 = crate::config::DEFAULT_MAX_IMAGE_PIXELS;
+
+/// Upper bounds applied to an uploaded image before it is handed to Typst.
+///
+/// Both bounds guard against memory exhaustion. `max_pixels` is the important one:
+/// PNG and WebP are decoded to RGBA (4 bytes per pixel) before embedding, so peak
+/// memory scales with the pixel count, not with the compressed file size. A body
+/// size limit alone is therefore not a memory guard — a well-compressed synthetic
+/// PNG can reach a very high pixel count in a small file.
+///
+/// JPEG is the exception: it is passed through to the PDF as `DCTDecode` without
+/// ever being decoded to RGBA, so its cost is proportional to the file size.
+#[derive(Clone, Copy, Debug)]
+pub struct ImageLimits {
+    /// Maximum allowed width or height, in pixels.
+    pub max_dimension_pixels: u32,
+    /// Maximum allowed total pixel count (width × height).
+    pub max_pixels: u64,
+}
+
+impl Default for ImageLimits {
+    fn default() -> Self {
+        Self {
+            max_dimension_pixels: MAX_IMAGE_DIMENSION_PIXELS,
+            max_pixels: MAX_IMAGE_PIXELS,
+        }
+    }
+}
 
 /// Bundles the arguments required to compile a Typst template with JSON data.
 ///
@@ -244,6 +271,8 @@ pub fn html_to_pdf(html: &str, converter: &HtmlConverter) -> Result<Vec<u8>> {
 ///
 /// Landscape images (width > height) are automatically placed on a
 /// landscape-oriented page so they fill the page without distortion.
+///
+/// `limits` bounds the accepted image size; see [`ImageLimits`].
 pub fn image_to_pdf<B>(
     image_bytes: B,
     image_path: &str,
@@ -252,6 +281,7 @@ pub fn image_to_pdf<B>(
     resources_dir: &Path,
     library: Arc<LazyHash<Library>>,
     comemo_eviction_threshold: usize,
+    limits: ImageLimits,
 ) -> Result<Vec<u8>>
 where
     B: AsRef<[u8]> + Send + Sync + 'static,
@@ -271,7 +301,7 @@ where
     let (w, h) = image_dimensions_by_format(data, detected_ext).with_context(|| {
         format!("Unsupported or corrupted image '{image_path}': unable to determine dimensions")
     })?;
-    validate_image_dimensions(w, h, image_path)?;
+    validate_image_dimensions(w, h, image_path, limits)?;
     let is_landscape = w > h;
 
     let mut vfiles = HashMap::new();
@@ -299,20 +329,27 @@ where
     result
 }
 
-fn validate_image_dimensions(width: u32, height: u32, image_path: &str) -> Result<()> {
+fn validate_image_dimensions(
+    width: u32,
+    height: u32,
+    image_path: &str,
+    limits: ImageLimits,
+) -> Result<()> {
     if width == 0 || height == 0 {
         anyhow::bail!("Image '{image_path}' has invalid dimensions: {width}x{height}");
     }
-    if width > MAX_IMAGE_DIMENSION_PIXELS || height > MAX_IMAGE_DIMENSION_PIXELS {
+    if width > limits.max_dimension_pixels || height > limits.max_dimension_pixels {
+        let max = limits.max_dimension_pixels;
         anyhow::bail!(
-            "Image '{image_path}' dimensions exceed the maximum of {MAX_IMAGE_DIMENSION_PIXELS} pixels: {width}x{height}"
+            "Image '{image_path}' is {width}x{height}, but width and height must each be at most {max} pixels"
         );
     }
 
     let pixels = u64::from(width) * u64::from(height);
-    if pixels > MAX_IMAGE_PIXELS {
+    if pixels > limits.max_pixels {
+        let max = limits.max_pixels;
         anyhow::bail!(
-            "Image '{image_path}' has {pixels} pixels, exceeding the maximum of {MAX_IMAGE_PIXELS}"
+            "Image '{image_path}' is {width}x{height} = {pixels} pixels in total, but the maximum total is {max} pixels"
         );
     }
     Ok(())
@@ -802,6 +839,7 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits::default(),
         )?;
         assert!(is_pdf(&bytes));
         Ok(())
@@ -822,6 +860,7 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits::default(),
         )?;
         assert!(is_pdf(&bytes));
         Ok(())
@@ -837,6 +876,7 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits::default(),
         );
         assert!(
             result.as_ref().err().is_some(),
@@ -911,12 +951,12 @@ Hello, world!
 
     #[test]
     fn validate_image_dimensions_accepts_limits() -> Result<()> {
-        validate_image_dimensions(8_192, 3_051, "/image.png")
+        validate_image_dimensions(8_192, 3_051, "/image.png", ImageLimits::default())
     }
 
     #[test]
     fn validate_image_dimensions_rejects_zero_dimensions() -> Result<()> {
-        let error = validate_image_dimensions(0, 1, "/image.png").err();
+        let error = validate_image_dimensions(0, 1, "/image.png", ImageLimits::default()).err();
         let error = error.context("zero dimensions should be rejected")?;
         assert!(error.to_string().contains("invalid dimensions"));
         Ok(())
@@ -924,17 +964,63 @@ Hello, world!
 
     #[test]
     fn validate_image_dimensions_rejects_excessive_dimension() -> Result<()> {
-        let error = validate_image_dimensions(8_193, 1, "/image.png").err();
+        let error = validate_image_dimensions(8_193, 1, "/image.png", ImageLimits::default()).err();
         let error = error.context("excessive dimensions should be rejected")?;
-        assert!(error.to_string().contains("dimensions exceed"));
+        let message = error.to_string();
+        assert!(
+            message.contains("width and height must each be at most 8192"),
+            "error should name the per-side limit: {message}"
+        );
         Ok(())
     }
 
     #[test]
     fn validate_image_dimensions_rejects_excessive_pixel_count() -> Result<()> {
-        let error = validate_image_dimensions(8_192, 3_052, "/image.png").err();
+        let error =
+            validate_image_dimensions(8_192, 3_052, "/image.png", ImageLimits::default()).err();
         let error = error.context("excessive pixel count should be rejected")?;
-        assert!(error.to_string().contains("pixels, exceeding"));
+        let message = error.to_string();
+        assert!(
+            message.contains("pixels in total"),
+            "error should name the total pixel limit: {message}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn validate_image_dimensions_accepts_raised_limits() -> Result<()> {
+        let limits = ImageLimits {
+            max_dimension_pixels: 16_384,
+            max_pixels: 100_000_000,
+        };
+        validate_image_dimensions(13_583, 5_417, "/image.jpg", limits)
+    }
+
+    #[test]
+    fn validate_image_dimensions_still_rejects_beyond_raised_limits() -> Result<()> {
+        let limits = ImageLimits {
+            max_dimension_pixels: 16_384,
+            max_pixels: 100_000_000,
+        };
+        let error = validate_image_dimensions(16_384, 16_384, "/image.png", limits).err();
+        let error = error.context("total pixel count should still be enforced")?;
+        assert!(error.to_string().contains("pixels in total"));
+        Ok(())
+    }
+
+    #[test]
+    fn validate_image_dimensions_rejects_dimension_below_default() -> Result<()> {
+        let limits = ImageLimits {
+            max_dimension_pixels: 1_000,
+            max_pixels: 100_000_000,
+        };
+        let error = validate_image_dimensions(1_001, 1, "/image.png", limits).err();
+        let error = error.context("lowered dimension limit should be enforced")?;
+        assert!(
+            error
+                .to_string()
+                .contains("width and height must each be at most 1000")
+        );
         Ok(())
     }
 
@@ -1256,6 +1342,7 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits::default(),
         )?;
         assert!(is_pdf(&bytes));
         Ok(())
@@ -1304,6 +1391,7 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits::default(),
         );
         assert!(
             result.is_err(),
@@ -1333,6 +1421,7 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits::default(),
         );
         assert!(result.is_err(), "Truncated JPEG with valid SOI should fail");
         let err_msg = result
@@ -1363,6 +1452,7 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits::default(),
         );
         assert!(
             result.is_err(),
@@ -1396,6 +1486,7 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits::default(),
         );
         assert!(
             result.is_err(),
@@ -1415,6 +1506,7 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits::default(),
         );
         match result {
             Ok(_) => anyhow::bail!("PNG bytes with JPEG path should have failed"),
@@ -1440,6 +1532,7 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits::default(),
         );
         match result {
             Ok(_) => anyhow::bail!("JPEG bytes with PNG path should have failed"),

--- a/src/rendering/pdf.rs
+++ b/src/rendering/pdf.rs
@@ -267,13 +267,45 @@ pub fn html_to_pdf(html: &str, converter: &HtmlConverter) -> Result<Vec<u8>> {
         .context("Failed to convert HTML to PDF")
 }
 
-/// Converts a PNG, JPEG, WebP, or SVG image into PDF bytes.
+/// Converts a PNG, JPEG, WebP, or SVG image into PDF bytes using the default
+/// [`ImageLimits`].
 ///
 /// Landscape images (width > height) are automatically placed on a
 /// landscape-oriented page so they fill the page without distortion.
 ///
-/// `limits` bounds the accepted image size; see [`ImageLimits`].
+/// Use [`image_to_pdf_with_limits`] to supply limits from configuration.
 pub fn image_to_pdf<B>(
+    image_bytes: B,
+    image_path: &str,
+    fonts: Arc<Fonts>,
+    root: &Path,
+    resources_dir: &Path,
+    library: Arc<LazyHash<Library>>,
+    comemo_eviction_threshold: usize,
+) -> Result<Vec<u8>>
+where
+    B: AsRef<[u8]> + Send + Sync + 'static,
+{
+    image_to_pdf_with_limits(
+        image_bytes,
+        image_path,
+        fonts,
+        root,
+        resources_dir,
+        library,
+        comemo_eviction_threshold,
+        ImageLimits::default(),
+    )
+}
+
+/// Converts a PNG, JPEG, WebP, or SVG image into PDF bytes, bounded by `limits`.
+///
+/// See [`image_to_pdf`] for the variant that uses the default limits.
+// One argument over the clippy threshold. Grouping them into a request struct, as
+// `typst_to_pdf` does with `CompileRequest`, would mean changing the signature of
+// the existing public `image_to_pdf`, so the argument list stays positional here.
+#[allow(clippy::too_many_arguments)]
+pub fn image_to_pdf_with_limits<B>(
     image_bytes: B,
     image_path: &str,
     fonts: Arc<Fonts>,
@@ -839,9 +871,51 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-            ImageLimits::default(),
         )?;
         assert!(is_pdf(&bytes));
+        Ok(())
+    }
+
+    /// `image_to_pdf` must keep behaving exactly as before this function gained a
+    /// limits-aware sibling, so the same image is accepted by both entry points.
+    #[test]
+    fn image_to_pdf_with_limits_accepts_image_within_raised_limits() -> Result<()> {
+        let image_bytes = fs::read(root_dir().join("resources").join("NAVLogoRed.png"))?;
+        let bytes = image_to_pdf_with_limits(
+            image_bytes,
+            "/image.png",
+            test_fonts()?,
+            &root_dir(),
+            &resources_dir(),
+            pdf_library(),
+            crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits {
+                max_dimension_pixels: 16_384,
+                max_pixels: 100_000_000,
+            },
+        )?;
+        assert!(is_pdf(&bytes));
+        Ok(())
+    }
+
+    #[test]
+    fn image_to_pdf_with_limits_rejects_image_above_limits() -> Result<()> {
+        let image_bytes = fs::read(root_dir().join("resources").join("NAVLogoRed.png"))?;
+        let result = image_to_pdf_with_limits(
+            image_bytes,
+            "/image.png",
+            test_fonts()?,
+            &root_dir(),
+            &resources_dir(),
+            pdf_library(),
+            crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+            ImageLimits {
+                max_dimension_pixels: 8_192,
+                max_pixels: 1,
+            },
+        );
+        let error = result.err().context("image should exceed max_pixels")?;
+        assert!(error.to_string().contains("pixels in total"));
         Ok(())
     }
 
@@ -860,7 +934,6 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-            ImageLimits::default(),
         )?;
         assert!(is_pdf(&bytes));
         Ok(())
@@ -876,7 +949,6 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-            ImageLimits::default(),
         );
         assert!(
             result.as_ref().err().is_some(),
@@ -1342,7 +1414,6 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-            ImageLimits::default(),
         )?;
         assert!(is_pdf(&bytes));
         Ok(())
@@ -1391,7 +1462,6 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-            ImageLimits::default(),
         );
         assert!(
             result.is_err(),
@@ -1421,7 +1491,6 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-            ImageLimits::default(),
         );
         assert!(result.is_err(), "Truncated JPEG with valid SOI should fail");
         let err_msg = result
@@ -1452,7 +1521,6 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-            ImageLimits::default(),
         );
         assert!(
             result.is_err(),
@@ -1486,7 +1554,6 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-            ImageLimits::default(),
         );
         assert!(
             result.is_err(),
@@ -1506,7 +1573,6 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-            ImageLimits::default(),
         );
         match result {
             Ok(_) => anyhow::bail!("PNG bytes with JPEG path should have failed"),
@@ -1532,7 +1598,6 @@ Hello, world!
             &resources_dir(),
             pdf_library(),
             crate::config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
-            ImageLimits::default(),
         );
         match result {
             Ok(_) => anyhow::bail!("JPEG bytes with PNG path should have failed"),

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -38,6 +38,8 @@ pub fn make_state_with_body_limit(
         max_concurrent_compilations: 0,
         semaphore_acquire_timeout_seconds: 10,
         comemo_eviction_threshold: config::DEFAULT_COMEMO_EVICTION_THRESHOLD,
+        max_image_dimension_pixels: config::DEFAULT_MAX_IMAGE_DIMENSION_PIXELS,
+        max_image_pixels: config::DEFAULT_MAX_IMAGE_PIXELS,
     };
     Ok(AppState {
         templates: Arc::new(templates),


### PR DESCRIPTION
 The image-to-PDF endpoint rejected images above 8192 px per side or
 25 megapixels, with both limits hardcoded. Move them to Config so
 consumers that need larger images can opt in, keeping today's values
 as defaults.

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Summary

Describe what this pull request changes and why.

## Checklist

- [x] I have run `cargo fmt -- --check`
- [x] I have run `cargo clippy --all-targets -- -D warnings`
- [x] I have run `cargo test --release -- --nocapture`
- [x] I have run `cargo build --release`
- [x] If performance may be affected, I have run `cargo bench --bench performance`
- [x] I have updated tests where relevant
