### PR TITLE
Avoid cropping images when converting to pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ curl -s -X POST http://localhost:8080/api/v1/genpdf/html/<your_appname> \
 
 Converts an image to PDF.
 
+The image is centred on the page. Landscape images (width > height) are placed on
+a landscape-oriented page. Images larger than the page are scaled down to fit,
+preserving their aspect ratio; images smaller than the page keep their natural
+size and are never scaled up. Pixels are treated as PostScript points (72 dpi),
+so a 595 × 842 px image fills an A4 page exactly.
+
 - Supported Request Content-Type:
   - `image/png`
   - `image/jpeg`

--- a/src/rendering/pdf.rs
+++ b/src/rendering/pdf.rs
@@ -240,7 +240,9 @@ pub fn html_to_pdf(html: &str, converter: &HtmlConverter) -> Result<Vec<u8>> {
 /// Converts a PNG, JPEG, WebP, or SVG image into PDF bytes.
 ///
 /// Landscape images (width > height) are automatically placed on a
-/// landscape-oriented page so they fill the page without distortion.
+/// landscape-oriented page. The image is centred and scaled down to fit the page
+/// while preserving its aspect ratio; images smaller than the page keep their
+/// natural size and are never scaled up.
 pub fn image_to_pdf<B>(
     image_bytes: B,
     image_path: &str,
@@ -304,18 +306,11 @@ where
         max_image_dimension_pixels,
         max_image_pixels,
     )?;
-    let is_landscape = w > h;
 
     let mut vfiles = HashMap::new();
     vfiles.insert(image_path.to_string(), Bytes::new(image_bytes));
 
-    let flipped = if is_landscape { "flipped: true, " } else { "" };
-    let source = format!(
-        r#"#set document(title: "Image", date: auto)
-#set page({flipped}margin: 0pt)
-#image("{image_path}", width: 100%, alt: "Uploaded image")
-"#
-    );
+    let source = image_typst_source(image_path, w, h);
 
     let result = typst_world::compile_to_pdf(
         fonts,
@@ -329,6 +324,58 @@ where
     comemo::evict(comemo_eviction_threshold);
     counter!("comemo_evictions_total", &[("output", "image")]).increment(1);
     result
+}
+
+/// A4 edge lengths in millimetres, matching the page size Typst uses by default.
+const A4_SHORT_EDGE_MM: f64 = 210.0;
+const A4_LONG_EDGE_MM: f64 = 297.0;
+
+/// Physical size of one image pixel, treating pixels as PostScript points (72 dpi).
+const MM_PER_PIXEL: f64 = 25.4 / 72.0;
+
+/// Returns the rendered size in millimetres for an image placed on an A4 page.
+///
+/// The image is scaled down to fit within the page while preserving its aspect
+/// ratio, and is never scaled up: an image smaller than the page keeps its natural
+/// size rather than being stretched and blurred.
+///
+/// Computing this here rather than leaving it to Typst means the result does not
+/// depend on how Typst interprets image DPI metadata, and can be tested directly.
+fn image_render_size_mm(width: u32, height: u32, is_landscape: bool) -> (f64, f64) {
+    let (page_width, page_height) = if is_landscape {
+        (A4_LONG_EDGE_MM, A4_SHORT_EDGE_MM)
+    } else {
+        (A4_SHORT_EDGE_MM, A4_LONG_EDGE_MM)
+    };
+
+    let natural_width = f64::from(width) * MM_PER_PIXEL;
+    let natural_height = f64::from(height) * MM_PER_PIXEL;
+
+    let scale = (page_width / natural_width)
+        .min(page_height / natural_height)
+        .min(1.0);
+
+    (natural_width * scale, natural_height * scale)
+}
+
+/// Builds the Typst source that renders a single image on its own page.
+///
+/// Landscape images (width > height) are placed on a landscape-oriented page so
+/// they fill more of it.
+fn image_typst_source(image_path: &str, width: u32, height: u32) -> String {
+    let is_landscape = width > height;
+    let (render_width, render_height) = image_render_size_mm(width, height, is_landscape);
+    let flipped = if is_landscape { "flipped: true, " } else { "" };
+
+    // `place` keeps the image out of the flow. A rendered size equal to the page
+    // size can therefore not round up and spill onto a second page, which is what
+    // an in-flow block combined with `fr` spacers would risk.
+    format!(
+        r#"#set document(title: "Image", date: auto)
+#set page({flipped}margin: 0pt)
+#place(center + horizon, image("{image_path}", width: {render_width:.4}mm, height: {render_height:.4}mm, alt: "Uploaded image"))
+"#
+    )
 }
 
 fn validate_image_dimensions(
@@ -950,6 +997,111 @@ Hello, world!
     #[test]
     fn validate_image_dimensions_accepts_limits() -> Result<()> {
         validate_image_dimensions(8_192, 3_051, "/image.png", 8_192, 25_000_000)
+    }
+
+    // --- Page fitting: images must never be cropped, and never upscaled ---
+
+    /// Both A4 edges, so a rendered size may equal but never exceed either.
+    fn assert_fits_a4(width: u32, height: u32) {
+        let is_landscape = width > height;
+        let (w_mm, h_mm) = image_render_size_mm(width, height, is_landscape);
+        let (page_w, page_h) = if is_landscape {
+            (297.0, 210.0)
+        } else {
+            (210.0, 297.0)
+        };
+        assert!(
+            w_mm <= page_w + 1e-6 && h_mm <= page_h + 1e-6,
+            "{width}x{height} rendered to {w_mm}x{h_mm} mm, which does not fit {page_w}x{page_h} mm"
+        );
+    }
+
+    /// The reported bug: tall images were cropped because width was pinned to 100%.
+    #[test]
+    fn tall_image_fits_within_page() {
+        assert_fits_a4(1_000, 3_000);
+    }
+
+    /// The second, unreported case: landscape images narrower than the A4 ratio
+    /// overflowed the flipped page.
+    #[test]
+    fn moderately_wide_image_fits_within_page() {
+        assert_fits_a4(1_200, 1_000);
+    }
+
+    #[test]
+    fn extreme_aspect_ratios_fit_within_page() {
+        for (w, h) in [
+            (13_583, 5_417),
+            (1_000, 1_000),
+            (8_000, 100),
+            (100, 8_000),
+            (1, 8_192),
+            (8_192, 1),
+        ] {
+            assert_fits_a4(w, h);
+        }
+    }
+
+    #[test]
+    fn aspect_ratio_is_preserved_when_scaling_down() {
+        let (w_mm, h_mm) = image_render_size_mm(1_000, 3_000, false);
+        let source_ratio = 1_000.0 / 3_000.0;
+        assert!(
+            ((w_mm / h_mm) - source_ratio).abs() < 1e-9,
+            "aspect ratio changed: {w_mm}x{h_mm} mm from a 1000x3000 image"
+        );
+    }
+
+    #[test]
+    fn image_smaller_than_page_keeps_natural_size() {
+        // 300x200 px at 72 dpi is 105.8 x 70.6 mm, well inside a landscape A4.
+        let (w_mm, h_mm) = image_render_size_mm(300, 200, true);
+        assert!((w_mm - 300.0 * MM_PER_PIXEL).abs() < 1e-9, "width was scaled");
+        assert!(
+            (h_mm - 200.0 * MM_PER_PIXEL).abs() < 1e-9,
+            "height was scaled"
+        );
+    }
+
+    #[test]
+    fn tiny_image_is_not_upscaled() {
+        let (w_mm, h_mm) = image_render_size_mm(32, 32, false);
+        let expected = 32.0 * MM_PER_PIXEL;
+        assert!((w_mm - expected).abs() < 1e-9 && (h_mm - expected).abs() < 1e-9);
+        assert!(w_mm < 12.0, "a 32 px icon should stay small, got {w_mm} mm");
+    }
+
+    /// An image exactly the size of the page must be left alone, not scaled by a
+    /// factor marginally above or below 1.
+    #[test]
+    fn image_exactly_page_sized_is_not_scaled() {
+        let width = (A4_SHORT_EDGE_MM / MM_PER_PIXEL).round() as u32;
+        let height = (A4_LONG_EDGE_MM / MM_PER_PIXEL).round() as u32;
+        let (w_mm, h_mm) = image_render_size_mm(width, height, false);
+        assert!(w_mm <= A4_SHORT_EDGE_MM + 1e-6);
+        assert!(h_mm <= A4_LONG_EDGE_MM + 1e-6);
+    }
+
+    #[test]
+    fn typst_source_flips_page_for_landscape_images_only() {
+        assert!(image_typst_source("/image.png", 1_200, 800).contains("flipped: true"));
+        assert!(!image_typst_source("/image.png", 800, 1_200).contains("flipped: true"));
+        assert!(
+            !image_typst_source("/image.png", 800, 800).contains("flipped: true"),
+            "square images should stay portrait"
+        );
+    }
+
+    #[test]
+    fn typst_source_centres_the_image_and_sets_explicit_size() {
+        let source = image_typst_source("/image.png", 1_000, 3_000);
+        assert!(source.contains("center + horizon"), "image is not centred");
+        assert!(
+            !source.contains("width: 100%"),
+            "explicit millimetre sizes must replace the relative width that caused cropping"
+        );
+        assert!(source.contains("mm,"), "expected millimetre sizes: {source}");
     }
 
     #[test]

--- a/src/rendering/pdf.rs
+++ b/src/rendering/pdf.rs
@@ -1057,7 +1057,10 @@ Hello, world!
     fn image_smaller_than_page_keeps_natural_size() {
         // 300x200 px at 72 dpi is 105.8 x 70.6 mm, well inside a landscape A4.
         let (w_mm, h_mm) = image_render_size_mm(300, 200, true);
-        assert!((w_mm - 300.0 * MM_PER_PIXEL).abs() < 1e-9, "width was scaled");
+        assert!(
+            (w_mm - 300.0 * MM_PER_PIXEL).abs() < 1e-9,
+            "width was scaled"
+        );
         assert!(
             (h_mm - 200.0 * MM_PER_PIXEL).abs() < 1e-9,
             "height was scaled"
@@ -1101,7 +1104,10 @@ Hello, world!
             !source.contains("width: 100%"),
             "explicit millimetre sizes must replace the relative width that caused cropping"
         );
-        assert!(source.contains("mm,"), "expected millimetre sizes: {source}");
+        assert!(
+            source.contains("mm,"),
+            "expected millimetre sizes: {source}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
 
 Tall images were cropped when converted to PDF. The generated Typst pinned the
 image to `width: 100%`, so its height followed from the aspect ratio and could
 exceed the page. With `margin: 0pt` anything past the page edge was simply not
 rendered.
 
 A4 has an aspect ratio of 1.414, and the page was flipped only when
 `width > height`. That means two cases were cropped:
 
 - **Tall images** where `height/width > 1.414` — a 1000x3000 image lost 53% of
   its height.
 - **Moderately wide images** where `width/height < 1.414` — a 1200x1000 image
   lost 15%. This case was not reported but follows from the same cause.
 
 Compute the rendered size in Rust instead. The image is scaled down to fit the
 page with its aspect ratio preserved, and centred. Pixels are treated as
 PostScript points (72 dpi).
 
 Images smaller than the page are no longer scaled up: the scale factor is capped
 at 1.0, so a 32x32 icon stays 11mm instead of being stretched to 210mm.
 
 Doing the arithmetic here rather than leaving it to Typst means the result does
 not depend on how Typst interprets image DPI metadata, and can be unit tested
 without rendering a PDF.
 
 ## Checklist
 
 - [x] I have run `cargo fmt -- --check`
 - [x] I have run `cargo clippy --all-targets -- -D warnings`
 - [x] I have run `cargo test --release -- --nocapture`
 - [x] I have run `cargo build --release`
 - [x] I have updated tests where relevant