### PR TITLE
fix(image): return 400/413 instead of 500 for rejected images

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,41 @@ ENV REQUEST_BODY_LIMIT_BYTES=3145728
 
 ```
 
+A request body larger than the limit is rejected with `413 Payload Too Large` before
+the handler runs.
+
+### Error responses
+
+All endpoints return errors as [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457)
+Problem Details with Content-Type `application/problem+json`:
+
+```json
+{
+  "type": "urn:pdfgenrs:error:image-too-large",
+  "title": "Payload Too Large",
+  "status": 413,
+  "detail": "Image '/image.png' has 25001984 pixels, exceeding the maximum of 25000000",
+  "trace_id": "…",
+  "request_id": "…"
+}
+```
+
+The `type` member is a stable, machine-readable identifier. Clients should branch on
+`type` (or the HTTP status), not on `detail` text. Known values:
+
+| `type`                                   | Status | Meaning                                              |
+|------------------------------------------|--------|------------------------------------------------------|
+| `urn:pdfgenrs:error:not-found`           | `404`  | Template or application not found                    |
+| `urn:pdfgenrs:error:unsupported-media-type` | `415` | Request Content-Type not supported                 |
+| `urn:pdfgenrs:error:invalid-image`       | `400`  | Image is malformed or contradicts its Content-Type   |
+| `urn:pdfgenrs:error:image-too-large`     | `413`  | Image exceeds a configured dimension or pixel limit  |
+| `urn:pdfgenrs:error:timeout`             | `408`  | Compilation exceeded `COMPILE_TIMEOUT_SECONDS`       |
+| `urn:pdfgenrs:error:overloaded`          | `503`  | Too many concurrent compilations (includes `Retry-After`) |
+| `urn:pdfgenrs:error:generation-failed`   | `500`  | Internal rendering error                             |
+
+`400` and `413` are permanent client errors: retrying the same request will not
+succeed. `503` and `408` are transient and may be retried.
+
 ### 1) Generate PDF from Typst + JSON
 
 #### `POST /api/v1/genpdf/{your_appname}/{template}`
@@ -198,8 +233,19 @@ so a 595 × 842 px image fills an A4 page exactly.
 - Response Content-Type: `application/pdf`
 - Success: `200 OK`
 - Common errors:
-  - `415 Unsupported Media Type` (if the image format is not supported)
-  - `500 Internal Server Error`
+  - `400 Bad Request` — the bytes are not a valid image, or contradict the declared
+    Content-Type (`type: urn:pdfgenrs:error:invalid-image`)
+  - `413 Payload Too Large` — the image exceeds `MAX_IMAGE_DIMENSION_PIXELS` (per side)
+    or `MAX_IMAGE_PIXELS` (total), or the body exceeds `REQUEST_BODY_LIMIT_BYTES`
+    (`type: urn:pdfgenrs:error:image-too-large`)
+  - `415 Unsupported Media Type` — the Content-Type is not a supported image format
+  - `500 Internal Server Error` — rendering failed
+
+Image dimensions are validated from the header before any pixels are decoded, so an
+oversized image is rejected cheaply without consuming compilation capacity. Note that a
+small file can still be rejected with `413` if its declared dimensions exceed the limits.
+See [Environment variables](#environment-variables) for `MAX_IMAGE_DIMENSION_PIXELS` and
+`MAX_IMAGE_PIXELS`.
 
 ```bash
 curl -s -X POST http://localhost:8080/api/v1/genpdf/image/<your_appname> \
@@ -273,6 +319,11 @@ Exposes Prometheus metrics for operational monitoring.
 | `typst_compilation_duration_seconds` | Histogram | output           | Typst compilation latency distribution |
 | `comemo_evictions_total`        | Counter   | output               | Number of comemo cache eviction runs |
 | `comemo_eviction_threshold`     | Gauge     | -                    | Configured `COMEMO_EVICTION_THRESHOLD` value |
+| `image_rejections_total`        | Counter   | reason               | Images rejected during validation, before compilation |
+
+The `reason` label on `image_rejections_total` is one of a fixed set:
+`undetectable_format`, `format_mismatch`, `unreadable_dimensions`, `zero_dimension`,
+`dimension_too_large`, `too_many_pixels`.
 
 By default, pdfgenrs loads all assets (`templates`, `data`) into memory on startup. Changes to files in these folders require an application restart.
 

--- a/src/http/routes/error.rs
+++ b/src/http/routes/error.rs
@@ -4,10 +4,23 @@ use axum::{
 };
 use metrics::counter;
 use opentelemetry::trace::TraceContextExt;
-use tracing::error;
+use tracing::{error, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+use crate::pdf::ImageRejection;
 use crate::request_id::current_request_id;
+
+impl From<ImageRejection> for ApiError {
+    fn from(rejection: ImageRejection) -> Self {
+        let reason = rejection.reason();
+        let detail = rejection.to_string();
+        if rejection.is_too_large() {
+            Self::ImageTooLarge { detail, reason }
+        } else {
+            Self::InvalidImage { detail, reason }
+        }
+    }
+}
 
 /// Centralized error type for API route handlers.
 ///
@@ -29,6 +42,19 @@ pub(crate) enum ApiError {
     },
     /// The request body content type is not supported.
     UnsupportedMediaType,
+    /// The uploaded image is malformed or contradicts its declared content type.
+    ///
+    /// The detail is safe to return to the client: it is built from a closed set of
+    /// format names and numeric dimensions, never from raw request content.
+    InvalidImage {
+        detail: String,
+        reason: &'static str,
+    },
+    /// The uploaded image is well-formed but exceeds a configured size limit.
+    ImageTooLarge {
+        detail: String,
+        reason: &'static str,
+    },
     /// The compilation task exceeded the configured timeout.
     RequestTimeout {
         app_name: String,
@@ -54,6 +80,8 @@ impl std::fmt::Debug for ApiError {
                 write!(f, "GenerationFailed({app_name}, {template_name:?})")
             }
             Self::UnsupportedMediaType => write!(f, "UnsupportedMediaType"),
+            Self::InvalidImage { reason, .. } => write!(f, "InvalidImage({reason})"),
+            Self::ImageTooLarge { reason, .. } => write!(f, "ImageTooLarge({reason})"),
             Self::RequestTimeout {
                 app_name,
                 template_name,
@@ -143,6 +171,25 @@ impl IntoResponse for ApiError {
                 "urn:pdfgenrs:error:unsupported-media-type",
                 "Unsupported media type",
             ),
+            Self::InvalidImage { ref detail, reason } => {
+                // Client error: logged at warn so it does not burn the 5xx error budget.
+                warn!(reason, detail = %detail, "Rejected malformed image upload");
+                counter!("image_rejections_total", &[("reason", reason)]).increment(1);
+                problem_response(
+                    StatusCode::BAD_REQUEST,
+                    "urn:pdfgenrs:error:invalid-image",
+                    detail,
+                )
+            }
+            Self::ImageTooLarge { ref detail, reason } => {
+                warn!(reason, detail = %detail, "Rejected oversized image upload");
+                counter!("image_rejections_total", &[("reason", reason)]).increment(1);
+                problem_response(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "urn:pdfgenrs:error:image-too-large",
+                    detail,
+                )
+            }
             Self::RequestTimeout {
                 ref app_name,
                 ref template_name,

--- a/src/http/routes/pdf.rs
+++ b/src/http/routes/pdf.rs
@@ -125,6 +125,17 @@ pub(crate) async fn post_pdf_from_image(
         return Err(ApiError::UnsupportedMediaType);
     };
 
+    // Validate before acquiring a compilation permit. Only the image header is read,
+    // so an invalid upload is rejected in microseconds without occupying a permit or
+    // a blocking thread. Returning 4xx here also stops well-behaved clients from
+    // retrying, which would otherwise re-buffer the body on every attempt.
+    let (_width, _height) = gen_pdf::validate_image(
+        &image_bytes,
+        image_path,
+        state.config.max_image_dimension_pixels,
+        state.config.max_image_pixels,
+    )?;
+
     let fonts = Arc::clone(&state.fonts);
     let root = Arc::clone(&state.root_dir);
     let resources_dir = Arc::clone(&state.resources_dir);
@@ -362,6 +373,91 @@ mod tests {
         Ok(())
     }
 
+    // --- Image rejection: client errors must not surface as 5xx (R8) ---
+
+    /// Builds a minimal but structurally valid PNG header with the given dimensions.
+    /// Only the bytes the validator reads are needed, since it never decodes pixels.
+    fn png_header(width: u32, height: u32) -> Vec<u8> {
+        let mut data = b"\x89PNG\r\n\x1a\n".to_vec();
+        data.extend_from_slice(&[0u8; 8]);
+        data.extend_from_slice(&width.to_be_bytes());
+        data.extend_from_slice(&height.to_be_bytes());
+        data
+    }
+
+    async fn post_image(state: AppState, content_type: &str, body: Vec<u8>) -> StatusCode {
+        let server = TestServer::new(make_router(state, false));
+        server
+            .post("/image/myapp")
+            .content_type(content_type)
+            .bytes(Bytes::from(body))
+            .await
+            .status_code()
+    }
+
+    #[tokio::test]
+    async fn post_image_returns_413_when_pixel_count_exceeds_limit() -> anyhow::Result<()> {
+        let state = make_state(HashMap::new(), HashMap::new(), false)?;
+        let max = state.config.max_image_pixels;
+        // One pixel past the limit, while staying inside the per-side dimension guard.
+        let height = u32::try_from(max / 8_000).unwrap_or(u32::MAX) + 1;
+
+        let status = post_image(state, "image/png", png_header(8_000, height)).await;
+
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn post_image_returns_413_when_dimension_exceeds_limit() -> anyhow::Result<()> {
+        let state = make_state(HashMap::new(), HashMap::new(), false)?;
+        let too_wide = state.config.max_image_dimension_pixels + 1;
+
+        let status = post_image(state, "image/png", png_header(too_wide, 1)).await;
+
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn post_image_returns_400_for_zero_dimensions() -> anyhow::Result<()> {
+        let state = make_state(HashMap::new(), HashMap::new(), false)?;
+
+        let status = post_image(state, "image/png", png_header(0, 100)).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        Ok(())
+    }
+
+    /// An oversized image must be rejected before a compilation permit is taken.
+    /// With the only permit held by another task, a request that still reached
+    /// `compile_blocking` would block and eventually return 503; returning 413
+    /// promptly proves validation now happens ahead of the semaphore.
+    #[tokio::test]
+    async fn post_image_rejects_oversized_without_consuming_a_permit() -> anyhow::Result<()> {
+        let mut state = make_state(HashMap::new(), HashMap::new(), false)?;
+        state.compile_semaphore = Some(Arc::new(tokio::sync::Semaphore::new(1)));
+        state.config.semaphore_acquire_timeout_seconds = 30;
+
+        let semaphore = state
+            .compile_semaphore
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("semaphore should be configured"))?;
+        let held = semaphore.acquire_owned().await?;
+
+        let too_wide = state.config.max_image_dimension_pixels + 1;
+        let status = timeout(
+            Duration::from_secs(5),
+            post_image(state, "image/png", png_header(too_wide, 1)),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("request blocked on the semaphore instead of failing fast"))?;
+
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+        drop(held);
+        Ok(())
+    }
+
     #[tokio::test]
     async fn post_pdf_client_timeout_cancels_request_and_followup_still_succeeds()
     -> anyhow::Result<()> {
@@ -584,10 +680,10 @@ mod tests {
             .bytes(Bytes::from(png_bytes))
             .await;
 
-        assert_ne!(
+        assert_eq!(
             response.status_code(),
-            StatusCode::OK,
-            "PNG bytes with Content-Type: image/jpeg should not produce a PDF"
+            StatusCode::BAD_REQUEST,
+            "PNG bytes with Content-Type: image/jpeg is a client error, not a server fault"
         );
         Ok(())
     }
@@ -886,7 +982,7 @@ mod tests {
     // --- Image-to-PDF error path tests ---
 
     #[tokio::test]
-    async fn post_pdf_from_image_returns_500_for_corrupted_png() -> anyhow::Result<()> {
+    async fn post_pdf_from_image_returns_400_for_corrupted_png() -> anyhow::Result<()> {
         let server = TestServer::new(make_router(
             make_state(HashMap::new(), HashMap::new(), false)?,
             false,
@@ -898,12 +994,12 @@ mod tests {
             .bytes(Bytes::from_static(b"not a valid png file"))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
         Ok(())
     }
 
     #[tokio::test]
-    async fn post_pdf_from_image_returns_500_for_corrupted_jpeg() -> anyhow::Result<()> {
+    async fn post_pdf_from_image_returns_400_for_corrupted_jpeg() -> anyhow::Result<()> {
         let server = TestServer::new(make_router(
             make_state(HashMap::new(), HashMap::new(), false)?,
             false,
@@ -915,12 +1011,12 @@ mod tests {
             .bytes(Bytes::from_static(b"not a valid jpeg file"))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
         Ok(())
     }
 
     #[tokio::test]
-    async fn post_pdf_from_image_returns_500_for_empty_image_bytes() -> anyhow::Result<()> {
+    async fn post_pdf_from_image_returns_400_for_empty_image_bytes() -> anyhow::Result<()> {
         let server = TestServer::new(make_router(
             make_state(HashMap::new(), HashMap::new(), false)?,
             false,
@@ -932,7 +1028,7 @@ mod tests {
             .bytes(Bytes::from_static(b""))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
         Ok(())
     }
 
@@ -1126,7 +1222,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn post_pdf_from_image_returns_500_for_corrupted_webp() -> anyhow::Result<()> {
+    async fn post_pdf_from_image_returns_400_for_corrupted_webp() -> anyhow::Result<()> {
         let server = TestServer::new(make_router(
             make_state(HashMap::new(), HashMap::new(), false)?,
             false,
@@ -1138,7 +1234,7 @@ mod tests {
             .bytes(Bytes::from_static(b"not a valid webp file"))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -789,7 +789,7 @@ Dev mode: #data.at("mode", default: "unknown")
     }
 
     #[tokio::test]
-    async fn build_router_image_corrupted_data_returns_500() -> anyhow::Result<()> {
+    async fn build_router_image_corrupted_data_returns_400() -> anyhow::Result<()> {
         let state = make_empty_state(false)?;
         let server = TestServer::new(build_router(state, metrics::test_metrics_handle()));
 
@@ -799,7 +799,7 @@ Dev mode: #data.at("mode", default: "unknown")
             .bytes(axum::body::Bytes::from_static(b"not a valid png"))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
         Ok(())
     }
 

--- a/src/rendering/pdf.rs
+++ b/src/rendering/pdf.rs
@@ -268,7 +268,173 @@ where
     )
 }
 
+/// Why an uploaded image was rejected before compilation started.
+///
+/// The variants separate malformed input (which maps to `400 Bad Request`) from
+/// input that is well-formed but exceeds a configured limit (`413 Content Too
+/// Large`). All variants describe a client error: none of them indicate a server
+/// fault.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImageRejection {
+    /// The bytes do not match any supported image format.
+    UndetectableFormat { image_path: String },
+    /// The detected format contradicts the declared content type.
+    FormatMismatch {
+        image_path: String,
+        declared: String,
+        detected: String,
+    },
+    /// The header could not be parsed into usable dimensions.
+    UnreadableDimensions { image_path: String },
+    /// The image reports a zero width or height.
+    ZeroDimension {
+        image_path: String,
+        width: u32,
+        height: u32,
+    },
+    /// Width or height exceeds the configured maximum.
+    DimensionTooLarge {
+        image_path: String,
+        width: u32,
+        height: u32,
+        max: u32,
+    },
+    /// The total pixel count exceeds the configured maximum.
+    TooManyPixels {
+        image_path: String,
+        pixels: u64,
+        max: u64,
+    },
+}
+
+impl ImageRejection {
+    /// Returns a stable, low-cardinality label identifying the rejection cause.
+    ///
+    /// Suitable as a metric label: the set of values is fixed and does not depend
+    /// on request content.
+    #[must_use]
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Self::UndetectableFormat { .. } => "undetectable_format",
+            Self::FormatMismatch { .. } => "format_mismatch",
+            Self::UnreadableDimensions { .. } => "unreadable_dimensions",
+            Self::ZeroDimension { .. } => "zero_dimension",
+            Self::DimensionTooLarge { .. } => "dimension_too_large",
+            Self::TooManyPixels { .. } => "too_many_pixels",
+        }
+    }
+
+    /// Returns whether the image was rejected for exceeding a size limit rather
+    /// than for being malformed.
+    #[must_use]
+    pub fn is_too_large(&self) -> bool {
+        matches!(
+            self,
+            Self::DimensionTooLarge { .. } | Self::TooManyPixels { .. }
+        )
+    }
+}
+
+impl std::fmt::Display for ImageRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UndetectableFormat { image_path } => write!(
+                f,
+                "Unsupported or corrupted image '{image_path}': unable to determine dimensions"
+            ),
+            Self::FormatMismatch {
+                image_path,
+                declared,
+                detected,
+            } => write!(
+                f,
+                "Image format mismatch for '{image_path}': declared '{declared}' but bytes are '{detected}'"
+            ),
+            Self::UnreadableDimensions { image_path } => write!(
+                f,
+                "Unsupported or corrupted image '{image_path}': unable to determine dimensions"
+            ),
+            Self::ZeroDimension {
+                image_path,
+                width,
+                height,
+            } => write!(
+                f,
+                "Image '{image_path}' has invalid dimensions: {width}x{height}"
+            ),
+            Self::DimensionTooLarge {
+                image_path,
+                width,
+                height,
+                max,
+            } => write!(
+                f,
+                "Image '{image_path}' dimensions exceed the maximum of {max} pixels: {width}x{height}"
+            ),
+            Self::TooManyPixels {
+                image_path,
+                pixels,
+                max,
+            } => write!(
+                f,
+                "Image '{image_path}' has {pixels} pixels, exceeding the maximum of {max}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ImageRejection {}
+
+/// Validates an uploaded image from its header alone and returns its dimensions.
+///
+/// Only the format magic bytes and the dimension fields are inspected, so this is
+/// cheap enough to run before acquiring a compilation permit. No pixel data is
+/// decoded and no allocation proportional to the image size is made.
+///
+/// # Errors
+/// Returns [`ImageRejection`] describing which check failed. Every variant denotes
+/// a client error.
+pub fn validate_image(
+    data: &[u8],
+    image_path: &str,
+    max_image_dimension_pixels: u32,
+    max_image_pixels: u64,
+) -> std::result::Result<(u32, u32), ImageRejection> {
+    let declared_ext = image_path.rsplit('.').next().unwrap_or("");
+    let detected_ext =
+        detect_image_format(data).ok_or_else(|| ImageRejection::UndetectableFormat {
+            image_path: image_path.to_string(),
+        })?;
+    if detected_ext != declared_ext {
+        return Err(ImageRejection::FormatMismatch {
+            image_path: image_path.to_string(),
+            declared: declared_ext.to_string(),
+            detected: detected_ext.to_string(),
+        });
+    }
+    let (width, height) = image_dimensions_by_format(data, detected_ext).ok_or_else(|| {
+        ImageRejection::UnreadableDimensions {
+            image_path: image_path.to_string(),
+        }
+    })?;
+
+    validate_image_dimensions(
+        width,
+        height,
+        image_path,
+        max_image_dimension_pixels,
+        max_image_pixels,
+    )?;
+
+    Ok((width, height))
+}
+
 /// Converts an image into PDF bytes using configured image dimension limits.
+///
+/// Validation is repeated here even when the caller has already run
+/// [`validate_image`]. The check only reads the image header, so the cost is
+/// negligible, and keeping it guarantees the limits cannot be bypassed by a future
+/// call site that forgets to validate first.
 #[allow(clippy::too_many_arguments)]
 pub fn image_to_pdf_with_limits<B>(
     image_bytes: B,
@@ -284,24 +450,8 @@ pub fn image_to_pdf_with_limits<B>(
 where
     B: AsRef<[u8]> + Send + Sync + 'static,
 {
-    let data = image_bytes.as_ref();
-    let declared_ext = image_path.rsplit('.').next().unwrap_or("");
-    let detected_ext = detect_image_format(data).ok_or_else(|| {
-        anyhow::anyhow!(
-            "Unsupported or corrupted image '{image_path}': unable to determine dimensions"
-        )
-    })?;
-    if detected_ext != declared_ext {
-        return Err(anyhow::anyhow!(
-            "Image format mismatch for '{image_path}': declared '{declared_ext}' but bytes are '{detected_ext}'"
-        ));
-    }
-    let (w, h) = image_dimensions_by_format(data, detected_ext).with_context(|| {
-        format!("Unsupported or corrupted image '{image_path}': unable to determine dimensions")
-    })?;
-    validate_image_dimensions(
-        w,
-        h,
+    let (w, h) = validate_image(
+        image_bytes.as_ref(),
         image_path,
         max_image_dimension_pixels,
         max_image_pixels,
@@ -378,27 +528,38 @@ fn image_typst_source(image_path: &str, width: u32, height: u32) -> String {
     )
 }
 
+/// Applies the configured dimension and pixel-count limits to already-parsed
+/// image dimensions.
 fn validate_image_dimensions(
     width: u32,
     height: u32,
     image_path: &str,
     max_image_dimension_pixels: u32,
     max_image_pixels: u64,
-) -> Result<()> {
+) -> std::result::Result<(), ImageRejection> {
     if width == 0 || height == 0 {
-        anyhow::bail!("Image '{image_path}' has invalid dimensions: {width}x{height}");
+        return Err(ImageRejection::ZeroDimension {
+            image_path: image_path.to_string(),
+            width,
+            height,
+        });
     }
     if width > max_image_dimension_pixels || height > max_image_dimension_pixels {
-        anyhow::bail!(
-            "Image '{image_path}' dimensions exceed the maximum of {max_image_dimension_pixels} pixels: {width}x{height}"
-        );
+        return Err(ImageRejection::DimensionTooLarge {
+            image_path: image_path.to_string(),
+            width,
+            height,
+            max: max_image_dimension_pixels,
+        });
     }
 
     let pixels = u64::from(width) * u64::from(height);
     if pixels > max_image_pixels {
-        anyhow::bail!(
-            "Image '{image_path}' has {pixels} pixels, exceeding the maximum of {max_image_pixels}"
-        );
+        return Err(ImageRejection::TooManyPixels {
+            image_path: image_path.to_string(),
+            pixels,
+            max: max_image_pixels,
+        });
     }
     Ok(())
 }
@@ -995,8 +1156,8 @@ Hello, world!
     }
 
     #[test]
-    fn validate_image_dimensions_accepts_limits() -> Result<()> {
-        validate_image_dimensions(8_192, 3_051, "/image.png", 8_192, 25_000_000)
+    fn validate_image_dimensions_accepts_limits() {
+        assert!(validate_image_dimensions(8_192, 3_051, "/image.png", 8_192, 25_000_000).is_ok());
     }
 
     // --- Page fitting: images must never be cropped, and never upscaled ---
@@ -1114,6 +1275,19 @@ Hello, world!
     fn validate_image_dimensions_rejects_zero_dimensions() -> Result<()> {
         let error = validate_image_dimensions(0, 1, "/image.png", 8_192, 25_000_000).err();
         let error = error.context("zero dimensions should be rejected")?;
+        assert!(matches!(
+            error,
+            ImageRejection::ZeroDimension {
+                width: 0,
+                height: 1,
+                ..
+            }
+        ));
+        assert_eq!(error.reason(), "zero_dimension");
+        assert!(
+            !error.is_too_large(),
+            "zero dimensions is a malformed image"
+        );
         assert!(error.to_string().contains("invalid dimensions"));
         Ok(())
     }
@@ -1122,6 +1296,16 @@ Hello, world!
     fn validate_image_dimensions_rejects_excessive_dimension() -> Result<()> {
         let error = validate_image_dimensions(8_193, 1, "/image.png", 8_192, 25_000_000).err();
         let error = error.context("excessive dimensions should be rejected")?;
+        assert!(matches!(
+            error,
+            ImageRejection::DimensionTooLarge {
+                width: 8_193,
+                max: 8_192,
+                ..
+            }
+        ));
+        assert_eq!(error.reason(), "dimension_too_large");
+        assert!(error.is_too_large());
         assert!(error.to_string().contains("dimensions exceed"));
         Ok(())
     }
@@ -1130,8 +1314,63 @@ Hello, world!
     fn validate_image_dimensions_rejects_excessive_pixel_count() -> Result<()> {
         let error = validate_image_dimensions(8_192, 3_052, "/image.png", 8_192, 25_000_000).err();
         let error = error.context("excessive pixel count should be rejected")?;
+        assert!(matches!(
+            error,
+            ImageRejection::TooManyPixels {
+                pixels: 25_001_984,
+                max: 25_000_000,
+                ..
+            }
+        ));
+        assert_eq!(error.reason(), "too_many_pixels");
+        assert!(error.is_too_large());
         assert!(error.to_string().contains("pixels, exceeding"));
         Ok(())
+    }
+
+    /// The dimension guard is checked before the pixel guard, so an image that
+    /// violates both is reported as a dimension failure.
+    #[test]
+    fn validate_image_dimensions_reports_dimension_before_pixel_count() -> Result<()> {
+        let error =
+            validate_image_dimensions(20_000, 20_000, "/image.png", 16_384, 64_000_000).err();
+        let error = error.context("both limits are exceeded")?;
+        assert_eq!(error.reason(), "dimension_too_large");
+        Ok(())
+    }
+
+    #[test]
+    fn validate_image_rejects_format_mismatch() -> Result<()> {
+        let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+        png.extend_from_slice(&[0u8; 8]);
+        png.extend_from_slice(&100u32.to_be_bytes());
+        png.extend_from_slice(&100u32.to_be_bytes());
+
+        let error = validate_image(&png, "/image.jpg", 16_384, 64_000_000).err();
+        let error = error.context("PNG bytes declared as JPEG should be rejected")?;
+        assert_eq!(error.reason(), "format_mismatch");
+        assert!(!error.is_too_large(), "a mismatch is a malformed request");
+        Ok(())
+    }
+
+    #[test]
+    fn validate_image_accepts_valid_png_and_returns_dimensions() -> Result<()> {
+        let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+        png.extend_from_slice(&[0u8; 8]);
+        png.extend_from_slice(&640u32.to_be_bytes());
+        png.extend_from_slice(&480u32.to_be_bytes());
+
+        let (width, height) = validate_image(&png, "/image.png", 16_384, 64_000_000)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        assert_eq!((width, height), (640, 480));
+        Ok(())
+    }
+
+    /// Exactly hitting the pixel limit is allowed; the guard rejects only strictly
+    /// greater counts.
+    #[test]
+    fn validate_image_dimensions_accepts_exact_pixel_limit() {
+        assert!(validate_image_dimensions(8_000, 8_000, "/image.png", 16_384, 64_000_000).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
 
 The image endpoint (`POST /api/v1/genpdf/image/{app}`) returned `500 Internal
 Server Error` whenever an upload was rejected during validation — including for
 plain client mistakes like an oversized image, a corrupt file, or bytes that
 don't match the declared `Content-Type`. This was confirmed in dev: a
 99,991,552 px image against a 64,000,000 px limit produced a 500.
 
 A 500 on a client error is harmful, not just cosmetic:
 - Well-behaved clients retry `5xx` (assuming it's transient) but not `4xx`. An
   oversized image was therefore retried indefinitely, and every attempt
   re-buffered the body (up to `REQUEST_BODY_LIMIT_BYTES`) and took a compilation
   semaphore permit — an amplification loop on exactly the resource the limit
   protects.
 - `5xx` burns the error budget and masks genuine rendering failures in metrics.
 
 ### Changes
 
 - Introduce `ImageRejection` in `rendering/pdf.rs`, separating malformed input
   from limit violations, and a `validate_image()` that inspects only the image
   header (no pixel decoding).
 - Validate **before** acquiring a compilation permit in `post_pdf_from_image`,
   so an invalid upload is rejected in microseconds without occupying a permit or
   a blocking thread.
 - Map rejections to correct status codes via two new `ApiError` variants:
   - `400 Bad Request` — malformed image or `Content-Type` mismatch
     (`urn:pdfgenrs:error:invalid-image`)
   - `413 Payload Too Large` — exceeds `MAX_IMAGE_DIMENSION_PIXELS` or
     `MAX_IMAGE_PIXELS` (`urn:pdfgenrs:error:image-too-large`)
 - Log client errors at `warn` (not `error`) so they don't inflate the 5xx
   budget, and add an `image_rejections_total{reason}` counter.
 - Keep the existing validation inside `image_to_pdf_with_limits` as defence in
   depth (header-only, negligible cost).
 - Update `README.md`: new "Error responses" section documenting the RFC 9457
   `problem+json` envelope and `type` URIs, image endpoint status codes, and the
   new metric.
 
 ### Behaviour change
 
 The response body and error messages are unchanged; only the status code and
 `type` URI differ. Consumers that treated these as `500` will now receive `400`
 or `413`. Error `detail` text is unchanged, and clients should branch on the
 `type` member or status code, not on `detail`.
 
 ### Testing
 
 - Flipped six tests that had codified the old `500` behaviour to assert `400`/`413`.
 - Added coverage: `413` for pixel-count and dimension overruns, `400` for
   corrupt/empty/zero-dimension/mismatched input, and a test proving an oversized
   image is rejected without consuming a semaphore permit.
 
 ## Checklist
 
 - [x] I have run `cargo fmt -- --check`
 - [x] I have run `cargo clippy --all-targets -- -D warnings`
 - [x] I have run `cargo test --release -- --nocapture`
 - [x] I have run `cargo build --release`
 - [x] If performance may be affected, I have run `cargo bench --bench performance`
 - [x] I have updated tests where relevant
